### PR TITLE
Add Sentry error monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
-# Error reporting (client-side DSN; also set this on Vercel for production builds)
+# Error reporting (client-side DSN; also set this on Vercel for production/preview builds)
 REACT_APP_SENTRY_DSN=
+
+# Sentry source maps (build-time only, not bundled). Set on Vercel, not in local .env.
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=ciclomapa
 
 # Map & routing (client-side — restrict by domain in each provider's console)
 REACT_APP_MAPBOX_ACCESS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Error reporting (client-side DSN; also set this on Vercel for production builds)
+REACT_APP_SENTRY_DSN=
+
 # Map & routing (client-side — restrict by domain in each provider's console)
 REACT_APP_MAPBOX_ACCESS_TOKEN=
 REACT_APP_OPENROUTESERVICE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-shrinkwrap.json
 .env
 .env.local
 .env.production
+.env.sentry-build-plugin
 
 # CicloMapa-specific
 *.geojson

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ We store a mirror of the OSM data in a Firebase Database. Any user (possibly an 
 
 Create a `.env` file in the project root (or set these in your environment) for the app to work fully:
 
+- `REACT_APP_SENTRY_DSN` — Sentry error reporting (also required on Vercel; CRA bakes it in at build time)
 - `REACT_APP_MAPBOX_ACCESS_TOKEN` — Mapbox map tiles and geocoding
 - `REACT_APP_OPENROUTESERVICE_API_KEY` — Route calculations (OpenRouteService)
 - `REACT_APP_GOOGLE_PLACES_API_KEY` — Place autocomplete in the directions panel (optional)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We store a mirror of the OSM data in a Firebase Database. Any user (possibly an 
 Create a `.env` file in the project root (or set these in your environment) for the app to work fully:
 
 - `REACT_APP_SENTRY_DSN` — Sentry error reporting (also required on Vercel; CRA bakes it in at build time)
+- `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` — build-time source map upload (Vercel only; not `REACT_APP_`, so they stay out of the bundle)
 - `REACT_APP_MAPBOX_ACCESS_TOKEN` — Mapbox map tiles and geocoding
 - `REACT_APP_OPENROUTESERVICE_API_KEY` — Route calculations (OpenRouteService)
 - `REACT_APP_GOOGLE_PLACES_API_KEY` — Place autocomplete in the directions panel (optional)

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,119 +1,147 @@
 const CracoLessPlugin = require('craco-less');
+const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 // Tree-shake antd in webpack only; applying this in Jest breaks TS/ESM transforms.
 const babelPlugins =
-    process.env.NODE_ENV === 'test'
-        ? []
-        : [
-              [
-                  'import',
-                  {
-                      libraryName: 'antd',
-                      libraryDirectory: 'es',
-                      style: false,
-                  },
-                  'antd',
-              ],
-          ];
+  process.env.NODE_ENV === 'test'
+    ? []
+    : [
+        [
+          'import',
+          {
+            libraryName: 'antd',
+            libraryDirectory: 'es',
+            style: false,
+          },
+          'antd',
+        ],
+      ];
 
 module.exports = {
-    babel: {
-        plugins: babelPlugins,
-    },
-    plugins: [
-        {
-            plugin: CracoLessPlugin,
-            options: {
-                lessLoaderOptions: {
-                    lessOptions: {
-                        javascriptEnabled: true,
-                    },
-                },
-            },
+  babel: {
+    plugins: babelPlugins,
+  },
+  plugins: [
+    {
+      plugin: CracoLessPlugin,
+      options: {
+        lessLoaderOptions: {
+          lessOptions: {
+            javascriptEnabled: true,
+          },
         },
-    ],
-    webpack: {
-        configure: (webpackConfig) => {
-            // Add rule to handle TypeScript files in node_modules
-            webpackConfig.module.rules.push({
-                test: /\.tsx?$/,
-                include: /node_modules\/(mapbox-pmtiles|pmtiles)/,
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: [
-                            ['@babel/preset-env', { targets: { node: 'current' } }],
-                            ['@babel/preset-typescript', { 
-                                allowDeclareFields: true,
-                                onlyRemoveTypeImports: true 
-                            }]
-                        ],
-                        plugins: [
-                            '@babel/plugin-proposal-class-properties'
-                        ]
-                    }
-                }
-            });
-
-            // Exclude these packages from source-map-loader
-            const sourceMapLoaderRule = webpackConfig.module.rules.find(
-                rule => rule.use && rule.use.find && rule.use.find(use => use.loader && use.loader.includes('source-map-loader'))
-            );
-            
-            if (sourceMapLoaderRule) {
-                sourceMapLoaderRule.exclude = [
-                    ...(sourceMapLoaderRule.exclude || []),
-                    /node_modules\/(mapbox-pmtiles|pmtiles)/
-                ];
-            }
-
-            // CRA's default webpack config runs Babel on most node_modules packages.
-            // mapbox-gl shares code between the main thread and its Web Worker; transpiling
-            // it injects helpers (e.g. _createClass) that exist only in the main bundle, so the
-            // worker throws ReferenceError for minified names like "a" / "o" in production.
-            // https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling
-            const mapboxGlPath = /[\\/]node_modules[\\/]mapbox-gl[\\/]/;
-            const oneOfRule = webpackConfig.module.rules.find((rule) => rule.oneOf)?.oneOf;
-            if (oneOfRule) {
-                for (const rule of oneOfRule) {
-                    const isNodeModulesBabelRule =
-                        rule.loader &&
-                        String(rule.loader).includes('babel-loader') &&
-                        !rule.include &&
-                        rule.test &&
-                        String(rule.test).includes('mjs');
-                    if (!isNodeModulesBabelRule) continue;
-
-                    if (Array.isArray(rule.exclude)) {
-                        rule.exclude.push(mapboxGlPath);
-                    } else if (rule.exclude) {
-                        rule.exclude = [rule.exclude, mapboxGlPath];
-                    } else {
-                        rule.exclude = mapboxGlPath;
-                    }
-                }
-            }
-
-            return webpackConfig;
-        }
+      },
     },
-    devServer: {
-        proxy: {
-            '/api/openrouteservice': {
-                target: 'https://api.openrouteservice.org',
-                changeOrigin: true,
-                pathRewrite: {
-                    '^/api/openrouteservice': ''
+  ],
+  webpack: {
+    configure: (webpackConfig) => {
+      // Add rule to handle TypeScript files in node_modules
+      webpackConfig.module.rules.push({
+        test: /\.tsx?$/,
+        include: /node_modules\/(mapbox-pmtiles|pmtiles)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              ['@babel/preset-env', { targets: { node: 'current' } }],
+              [
+                '@babel/preset-typescript',
+                {
+                  allowDeclareFields: true,
+                  onlyRemoveTypeImports: true,
                 },
-                secure: true,
-                logLevel: 'debug'
-            },
-            '/pmtiles': {
-                target: 'http://localhost:3000',
-                changeOrigin: true,
-                secure: false,
-                logLevel: 'debug'
-            }
+              ],
+            ],
+            plugins: ['@babel/plugin-proposal-class-properties'],
+          },
+        },
+      });
+
+      // Exclude these packages from source-map-loader
+      const sourceMapLoaderRule = webpackConfig.module.rules.find(
+        (rule) =>
+          rule.use &&
+          rule.use.find &&
+          rule.use.find((use) => use.loader && use.loader.includes('source-map-loader'))
+      );
+
+      if (sourceMapLoaderRule) {
+        sourceMapLoaderRule.exclude = [
+          ...(sourceMapLoaderRule.exclude || []),
+          /node_modules\/(mapbox-pmtiles|pmtiles)/,
+        ];
+      }
+
+      // CRA's default webpack config runs Babel on most node_modules packages.
+      // mapbox-gl shares code between the main thread and its Web Worker; transpiling
+      // it injects helpers (e.g. _createClass) that exist only in the main bundle, so the
+      // worker throws ReferenceError for minified names like "a" / "o" in production.
+      // https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling
+      const mapboxGlPath = /[\\/]node_modules[\\/]mapbox-gl[\\/]/;
+      const oneOfRule = webpackConfig.module.rules.find((rule) => rule.oneOf)?.oneOf;
+      if (oneOfRule) {
+        for (const rule of oneOfRule) {
+          const isNodeModulesBabelRule =
+            rule.loader &&
+            String(rule.loader).includes('babel-loader') &&
+            !rule.include &&
+            rule.test &&
+            String(rule.test).includes('mjs');
+          if (!isNodeModulesBabelRule) continue;
+
+          if (Array.isArray(rule.exclude)) {
+            rule.exclude.push(mapboxGlPath);
+          } else if (rule.exclude) {
+            rule.exclude = [rule.exclude, mapboxGlPath];
+          } else {
+            rule.exclude = mapboxGlPath;
+          }
         }
-    }
+      }
+
+      if (process.env.NODE_ENV === 'production') {
+        const sentryOrg = process.env.SENTRY_ORG;
+        const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+        if (sentryOrg && sentryAuthToken) {
+          // Hidden maps: not fetched by the browser. Upload, then delete so they
+          // never ship on Vercel.
+          webpackConfig.devtool = 'hidden-source-map';
+          webpackConfig.plugins.push(
+            sentryWebpackPlugin({
+              org: sentryOrg,
+              project: process.env.SENTRY_PROJECT || 'ciclomapa',
+              authToken: sentryAuthToken,
+              telemetry: false,
+              sourcemaps: {
+                filesToDeleteAfterUpload: ['./build/**/*.map'],
+              },
+            })
+          );
+        } else {
+          webpackConfig.devtool = false;
+        }
+      }
+
+      return webpackConfig;
+    },
+  },
+  devServer: {
+    proxy: {
+      '/api/openrouteservice': {
+        target: 'https://api.openrouteservice.org',
+        changeOrigin: true,
+        pathRewrite: {
+          '^/api/openrouteservice': '',
+        },
+        secure: true,
+        logLevel: 'debug',
+      },
+      '/pmtiles': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
+        logLevel: 'debug',
+      },
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@playwright/test": "^1.52.0",
+    "@sentry/webpack-plugin": "^5.4.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fontsource/boldonse": "^5.2.4",
     "@fontsource/jetbrains-mono": "^5.3.0",
     "@mapbox/mapbox-sdk": "^0.16.2",
+    "@sentry/react": "^10.73.0",
     "@turf/bbox": "^7.2.0",
     "@turf/circle": "^7.2.0",
     "@turf/distance": "^7.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
+import './instrument';
+
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client'; // Note the updated import
+import * as Sentry from '@sentry/react';
 import App from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
@@ -60,8 +63,23 @@ if (window.visualViewport) {
   window.visualViewport.addEventListener('scroll', handleResize);
 }
 
+function SentryFallback() {
+  return (
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+      <p>Algo deu errado. Recarregue a página ou tente de novo em instantes.</p>
+      <button type="button" onClick={() => window.location.reload()}>
+        Recarregar
+      </button>
+    </div>
+  );
+}
+
 // Create a root using ReactDOM.createRoot
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'), {
+  onUncaughtError: Sentry.reactErrorHandler(),
+  onCaughtError: Sentry.reactErrorHandler(),
+  onRecoverableError: Sentry.reactErrorHandler(),
+});
 
 const shouldExposeDebugHandles =
   new URLSearchParams(window.location.search).has('debug') && process.env.NODE_ENV !== 'production';
@@ -95,10 +113,12 @@ function AppRoutes() {
 
 // Render the app using the new root API
 root.render(
-  <Router>
-    <AppRoutes />
-    <SpeedInsights />
-  </Router>
+  <Sentry.ErrorBoundary fallback={<SentryFallback />}>
+    <Router>
+      <AppRoutes />
+      <SpeedInsights />
+    </Router>
+  </Sentry.ErrorBoundary>
 );
 
 // --- Service Worker update lifecycle ---

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -2,18 +2,22 @@ import * as Sentry from '@sentry/react';
 
 const dsn = process.env.REACT_APP_SENTRY_DSN;
 
+// Only report from real deploys: ciclomapa.app and Vercel preview URLs (beta).
+// Skip localhost / yarn start even if the DSN is in .env.
 function sentryEnvironment() {
-  if (process.env.NODE_ENV !== 'production') return 'development';
-  if (typeof window !== 'undefined' && window.location.hostname === 'ciclomapa.app') {
-    return 'production';
-  }
-  return 'preview';
+  if (typeof window === 'undefined') return null;
+  const host = window.location.hostname;
+  if (host === 'ciclomapa.app' || host === 'www.ciclomapa.app') return 'production';
+  if (host.endsWith('.vercel.app')) return 'preview';
+  return null;
 }
 
-if (dsn && process.env.NODE_ENV !== 'test') {
+const environment = sentryEnvironment();
+
+if (dsn && environment) {
   Sentry.init({
     dsn,
-    environment: sentryEnvironment(),
+    environment,
     sendDefaultPii: false,
     dataCollection: {
       userInfo: false,

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -1,0 +1,29 @@
+import * as Sentry from '@sentry/react';
+
+const dsn = process.env.REACT_APP_SENTRY_DSN;
+
+function sentryEnvironment() {
+  if (process.env.NODE_ENV !== 'production') return 'development';
+  if (typeof window !== 'undefined' && window.location.hostname === 'ciclomapa.app') {
+    return 'production';
+  }
+  return 'preview';
+}
+
+if (dsn && process.env.NODE_ENV !== 'test') {
+  Sentry.init({
+    dsn,
+    environment: sentryEnvironment(),
+    sendDefaultPii: false,
+    dataCollection: {
+      userInfo: false,
+      httpBodies: [],
+    },
+    // Chunk-load failures already trigger a reload in index.js; don't burn quota on them.
+    ignoreErrors: [
+      /Loading chunk [\d]+ failed/,
+      'ResizeObserver loop limit exceeded',
+      'ResizeObserver loop completed with undelivered notifications',
+    ],
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,7 +128,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.29.6":
+"@babel/core@^7.18.5", "@babel/core@^7.29.6":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
@@ -2436,6 +2436,11 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz#f4c663e862f06dc98ca4d453862c46902789a18d"
+  integrity sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==
+
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -3204,6 +3209,79 @@
     "@sentry/replay" "10.73.0"
     "@sentry/replay-canvas" "10.73.0"
 
+"@sentry/bundler-plugins@^10.64.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugins/-/bundler-plugins-10.73.0.tgz#679b8accb2acb1d754f48196464d32a644853073"
+  integrity sha512-4X5m2hoqgKO6SxHR7MF9QnvxPNk0hwTJFixDJ/pzQGVM+C34j/rSabouBqd0M+ZdxFeAt/9kA5X0TyeceNo9YQ==
+  dependencies:
+    "@babel/core" "^7.18.5"
+    "@sentry/cli" "^2.58.6"
+    "@sentry/core" "10.73.0"
+    dotenv "^17.4.2"
+    find-up "^5.0.0"
+    glob "^13.0.6"
+    magic-string "~0.30.8"
+
+"@sentry/cli-darwin@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz#38fd82751014b287e58e99ef948d01ca1e09f41d"
+  integrity sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==
+
+"@sentry/cli-linux-arm64@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz#6e660e457af7928c1be8191c77646801fe3fa6a0"
+  integrity sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==
+
+"@sentry/cli-linux-arm@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz#41256912d636193d2a67985b6c9b3efbbe6a47c9"
+  integrity sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==
+
+"@sentry/cli-linux-i686@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz#278e7696d82e51dfbfd7d82ec125dda65d249a43"
+  integrity sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==
+
+"@sentry/cli-linux-x64@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz#57860d46ac3397c33bbcc6224ac19b7de2502c18"
+  integrity sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==
+
+"@sentry/cli-win32-arm64@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz#9335a5d2411381dca1d6b11fdd71a4342b375fc3"
+  integrity sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==
+
+"@sentry/cli-win32-i686@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz#2afd19536ef111af43538ccc5f9c8c0b179d930e"
+  integrity sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==
+
+"@sentry/cli-win32-x64@2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz#8d0e70b5660cc82a7763a4bbe9346cf18e49e07e"
+  integrity sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==
+
+"@sentry/cli@^2.58.6":
+  version "2.58.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.58.6.tgz#72edb4977d822757511b279e006b00f139e24945"
+  integrity sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+  optionalDependencies:
+    "@sentry/cli-darwin" "2.58.6"
+    "@sentry/cli-linux-arm" "2.58.6"
+    "@sentry/cli-linux-arm64" "2.58.6"
+    "@sentry/cli-linux-i686" "2.58.6"
+    "@sentry/cli-linux-x64" "2.58.6"
+    "@sentry/cli-win32-arm64" "2.58.6"
+    "@sentry/cli-win32-i686" "2.58.6"
+    "@sentry/cli-win32-x64" "2.58.6"
+
 "@sentry/conventions@^0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
@@ -3247,6 +3325,13 @@
   dependencies:
     "@sentry/browser-utils" "10.73.0"
     "@sentry/core" "10.73.0"
+
+"@sentry/webpack-plugin@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-5.4.0.tgz#0aec09da3302649cd46b367f518bc0d028496955"
+  integrity sha512-J3a0BvUZ75Qxy+v/Ap3Hx4ZEcSjlPHZ/jDtxdRhXQCyNeEb8xq0uUBTI9VLtGk2eNeNucOxOEJ5ngqdNjnEH/A==
+  dependencies:
+    "@sentry/bundler-plugins" "^10.64.0"
 
 "@sinclair/typebox@0.25.24":
   version "0.25.24"
@@ -6819,6 +6904,11 @@ dotenv@^10.0.0:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
@@ -8301,7 +8391,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^13.0.0:
+glob@^13.0.0, glob@^13.0.6:
   version "13.0.6"
   resolved "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz"
   integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
@@ -10364,6 +10454,13 @@ magic-string@^0.25.0, magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+magic-string@~0.30.8:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
@@ -12145,6 +12242,11 @@ process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-polyfill@8.1.3:
   version "8.1.3"
   resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz"
@@ -12228,6 +12330,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -15012,7 +15119,7 @@ which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,6 +3184,70 @@
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz"
   integrity sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==
 
+"@sentry/browser-utils@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.73.0.tgz#7349f5414f1663c005cca69db48cef1d63b3b1e2"
+  integrity sha512-qQygxJZ+RV779+iL1+lrJ4f4sZLgbgW0/JWPNp0YlcEAE62yCsdKbqoTEjB/EugdS4mSjBMX0chZC6rblu2Ycw==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.73.0"
+
+"@sentry/browser@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.73.0.tgz#22c3636dd170479a58c9c81507bab72f88e94233"
+  integrity sha512-HqTe1S5RrWLufhX2LaFP3yNoMxfNDroh120bq1zdGHZfFDBMJQ0CDXxHO+L4UJfQ5dWdCCzWbXIAiZuWGa/DFQ==
+  dependencies:
+    "@sentry/browser-utils" "10.73.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.73.0"
+    "@sentry/feedback" "10.73.0"
+    "@sentry/replay" "10.73.0"
+    "@sentry/replay-canvas" "10.73.0"
+
+"@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+
+"@sentry/core@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.73.0.tgz#464593d1a2cec6655da681911a2d60d26033e4ab"
+  integrity sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+
+"@sentry/feedback@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.73.0.tgz#e086f789cf7f1f671d6a1ef08e80b2ef6db655a4"
+  integrity sha512-D6nSngX+e46Mae2/oh2bxBvxNK1z2NERbuMAhB5sx9x4xMBWIyGnYYTECehvEqV9+AqGAgxxhOZoYIG3AmRwww==
+  dependencies:
+    "@sentry/core" "10.73.0"
+
+"@sentry/react@^10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-10.73.0.tgz#03dbb3fb70ea15dd0c7161d307afca37ab24c7da"
+  integrity sha512-wJrzS98ddPvhGS/MKNHZyE8X7ecd4KwKdz7fHino2qkqBBrF4cxWr+q/uLTIk5PYWMkeJ4oKMjHAjOqmzGR4tg==
+  dependencies:
+    "@sentry/browser" "10.73.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.73.0"
+
+"@sentry/replay-canvas@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.73.0.tgz#32fe5a7120d05c97fd9828ac15f09d37e1848f76"
+  integrity sha512-sxa2lKkHPfF/j5xFpW7gocthWXRqyoHz8KCPy6yGc8plT477nl57iGSKhQDYsx1Ny10TLjs7YkIuPP1GY/Ax2Q==
+  dependencies:
+    "@sentry/core" "10.73.0"
+    "@sentry/replay" "10.73.0"
+
+"@sentry/replay@10.73.0":
+  version "10.73.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.73.0.tgz#25d53335e3dee9324c0b17511506ea4be17ac6dd"
+  integrity sha512-nN2wjN/Y0J5BOJV5hqRHUEBfxwUsipp1PKjcDHh6Fpxnrtfldu3Y99E8cQInseo5heFdzEvrOHBBrqWZXOHVKQ==
+  dependencies:
+    "@sentry/browser-utils" "10.73.0"
+    "@sentry/core" "10.73.0"
+
 "@sinclair/typebox@0.25.24":
   version "0.25.24"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz"


### PR DESCRIPTION
## Summary
- Adds `@sentry/react` for uncaught errors and React 19 render crashes only (no session replay, no tracing, no `console.error` vacuum).
- Lives on a branch off `master` so it can merge before `stack/pmtiles-native-core`.
- Needs `REACT_APP_SENTRY_DSN` on Vercel (CRA inlines it at build time). Local `.env` is gitignored.

## Test plan
- [ ] Set `REACT_APP_SENTRY_DSN` on the Vercel project (Production + Preview).
- [ ] Merge and confirm a production/preview deploy.
- [ ] In Sentry, throw a test error once (or use the wizard button locally) and check it lands with environment `production` or `preview`.
- [ ] Confirm Issues is not flooded with chunk-load / ResizeObserver noise.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sentry error monitoring for application, uncaught, and recoverable errors.
  - Added a fallback error screen in Portuguese with an option to reload the application.
  - Error reporting can be configured for development, production, and preview environments.

- **Documentation**
  - Documented the required Sentry DSN environment variable, including production build configuration on Vercel.
  - Added the Sentry integration dependency to the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->