### PR TITLE
Move Airtable behind Vercel Functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,14 @@ S3_PMTILES_PREFIX=pmtiles/
 
 # Overpass etiquette (optional; recommended for automated builds)
 CICLOMAPA_FROM=you@example.com
+
+# Airtable — server-only (Vercel Functions). Do NOT prefix with REACT_APP_; that would
+# bake the token into the public JS bundle. Set these in Vercel Production/Preview env,
+# and locally when using `yarn dev:vercel`.
+# After deploying the functions, rotate/revoke any token that previously lived in REACT_APP_AIRTABLE_API_KEY.
+AIRTABLE_API_KEY=
+AIRTABLE_BASE_ID=
+
+# Optional Playwright smoke for the deployed proxy (GET only; does not create comments).
+# Example: https://ciclomapa.app  or  http://localhost:3000  (with `yarn dev:vercel`)
+AIRTABLE_API_SMOKE_BASE_URL=

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
   rules: {
     'react/prop-types': ['warn', { skipUndeclared: false }],
   },
+  overrides: [
+    {
+      files: ['api/**/*.js'],
+      env: { node: true },
+    },
+  ],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test-results/
 playwright-report/
 blob-report/
 .pmtiles-work/
+.env*.local

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Create a `.env` file in the project root (or set these in your environment) for 
 - `REACT_APP_OPENROUTESERVICE_API_KEY` — Route calculations (OpenRouteService)
 - `REACT_APP_GOOGLE_PLACES_API_KEY` — Place autocomplete in the directions panel (optional)
 - `REACT_APP_PMTILES_URL` / `REACT_APP_PMTILES_FILENAME` — Vector tile archive served from S3 (see `.env.example`)
+- `AIRTABLE_API_KEY` / `AIRTABLE_BASE_ID` — server-only, used by `/api/airtable/*` Vercel Functions. Never `REACT_APP_`. CRA inlines every `REACT_APP_*` variable that is still in `.env`, even if unused. For local comments/metadata, run `yarn dev:vercel`. After the first deploy, revoke any token that used to be in `REACT_APP_AIRTABLE_API_KEY`.
 
 ### PMtiles data pipeline
 
@@ -84,6 +85,8 @@ To start the local server:
 ```
 yarn start
 ```
+
+Comments and city metadata go through Vercel Functions (`/api/airtable/*`). For those locally, use `yarn dev:vercel` with `AIRTABLE_API_KEY` and `AIRTABLE_BASE_ID` in `.env`. `vercel.json` points that at `yarn start` (CRACO). If Vercel falls back to `react-scripts start`, Less never compiles and the UI looks broken. Plain `yarn start` still runs the SPA, but those API routes 404.
 
 To deploy to production server:
 

--- a/api/_lib/airtable.js
+++ b/api/_lib/airtable.js
@@ -1,0 +1,109 @@
+const AIRTABLE_API_BASE = 'https://api.airtable.com/v0';
+
+function getAirtableConfig() {
+  const apiKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+  if (!apiKey || !baseId) {
+    const err = new Error('Airtable is not configured');
+    err.statusCode = 500;
+    throw err;
+  }
+  return { apiKey, baseId };
+}
+
+function airtableError(message, statusCode) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+async function readAirtableJson(response) {
+  if (!response.ok) {
+    throw airtableError('Airtable request failed', 502);
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw airtableError('Airtable request failed', 502);
+  }
+}
+
+async function fetchAirtableTable(tableName, { view } = {}) {
+  const { apiKey, baseId } = getAirtableConfig();
+  const records = [];
+  let offset;
+
+  do {
+    const url = new URL(
+      `${AIRTABLE_API_BASE}/${encodeURIComponent(baseId)}/${encodeURIComponent(tableName)}`
+    );
+    if (view) url.searchParams.set('view', view);
+    if (offset) url.searchParams.set('offset', offset);
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    const data = await readAirtableJson(response);
+    if (Array.isArray(data.records)) {
+      records.push(...data.records);
+    }
+    offset = data.offset;
+  } while (offset);
+
+  return records;
+}
+
+async function createAirtableRecord(tableName, fields) {
+  const { apiKey, baseId } = getAirtableConfig();
+  const url = `${AIRTABLE_API_BASE}/${encodeURIComponent(baseId)}/${encodeURIComponent(tableName)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ records: [{ fields }] }),
+  });
+  return readAirtableJson(response);
+}
+
+function sendJson(res, status, body, headers = {}) {
+  Object.entries(headers).forEach(([key, value]) => {
+    res.setHeader(key, value);
+  });
+  res.status(status).json(body);
+}
+
+function publicErrorMessage(err, status) {
+  if (status === 400) return err.message || 'Invalid request';
+  if (status === 405) return 'Method not allowed';
+  if (status === 500 && err.message === 'Airtable is not configured') {
+    return 'Airtable is not configured';
+  }
+  return 'Airtable request failed';
+}
+
+function sendError(res, err) {
+  const status = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  sendJson(
+    res,
+    status,
+    { error: publicErrorMessage(err, status) },
+    { 'Cache-Control': 'no-store' }
+  );
+}
+
+function methodNotAllowed(res, allow) {
+  res.setHeader('Allow', allow);
+  sendJson(res, 405, { error: 'Method not allowed' }, { 'Cache-Control': 'no-store' });
+}
+
+module.exports = {
+  fetchAirtableTable,
+  createAirtableRecord,
+  sendJson,
+  sendError,
+  methodNotAllowed,
+};

--- a/api/airtable/comments.js
+++ b/api/airtable/comments.js
@@ -1,0 +1,176 @@
+const {
+  fetchAirtableTable,
+  createAirtableRecord,
+  sendJson,
+  sendError,
+  methodNotAllowed,
+} = require('../_lib/airtable');
+
+const COMMENTS_TABLE_NAME = 'Comments';
+const TAGS_LIST_COMMENT_ID = 44;
+const DEFAULT_STATUS = 'Aberta';
+const HONEYPOT_FIELD = 'website';
+const PRIVATE_FIELDS = ['email'];
+const GET_CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
+
+const MAX_TEXT_LENGTH = 2000;
+const MAX_LOCATION_LENGTH = 300;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 80;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const LATLONG_RE = /^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/;
+
+function badRequest(message) {
+  const err = new Error(message);
+  err.statusCode = 400;
+  return err;
+}
+
+function stripPrivateFields(record) {
+  if (!record || typeof record !== 'object') return record;
+  const fields = record.fields && typeof record.fields === 'object' ? { ...record.fields } : {};
+  PRIVATE_FIELDS.forEach((key) => {
+    delete fields[key];
+  });
+  return { ...record, fields };
+}
+
+function readJsonBody(req) {
+  if (req.body == null || req.body === '') {
+    throw badRequest('Invalid request');
+  }
+  if (typeof req.body === 'string') {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      throw badRequest('Invalid request');
+    }
+  }
+  if (typeof req.body !== 'object' || Array.isArray(req.body)) {
+    throw badRequest('Invalid request');
+  }
+  return req.body;
+}
+
+function parseLatLong(value) {
+  if (typeof value !== 'string') return null;
+  const match = value.match(LATLONG_RE);
+  if (!match) return null;
+  const lat = Number(match[1]);
+  const lng = Number(match[2]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  return `${lat},${lng}`;
+}
+
+function validateCommentPayload(body) {
+  const honeypot = body[HONEYPOT_FIELD];
+  if (honeypot != null && String(honeypot).trim() !== '') {
+    throw badRequest('Invalid request');
+  }
+
+  const latlong = parseLatLong(body.latlong);
+  if (!latlong) {
+    throw badRequest('Invalid request');
+  }
+
+  if (typeof body.location !== 'string' || body.location.trim().length === 0) {
+    throw badRequest('Invalid request');
+  }
+  const location = body.location.trim();
+  if (location.length > MAX_LOCATION_LENGTH) {
+    throw badRequest('Invalid request');
+  }
+
+  if (typeof body.text !== 'string' || body.text.trim().length === 0) {
+    throw badRequest('Invalid request');
+  }
+  const text = body.text.trim();
+  if (text.length > MAX_TEXT_LENGTH) {
+    throw badRequest('Invalid request');
+  }
+
+  if (!Array.isArray(body.tags) || body.tags.length === 0 || body.tags.length > MAX_TAGS) {
+    throw badRequest('Invalid request');
+  }
+  const tags = body.tags.map((tag) => {
+    if (typeof tag !== 'string' || tag.trim().length === 0 || tag.trim().length > MAX_TAG_LENGTH) {
+      throw badRequest('Invalid request');
+    }
+    return tag.trim();
+  });
+
+  let email;
+  if (body.email != null && body.email !== '') {
+    if (
+      typeof body.email !== 'string' ||
+      body.email.length > MAX_EMAIL_LENGTH ||
+      !EMAIL_RE.test(body.email.trim())
+    ) {
+      throw badRequest('Invalid request');
+    }
+    email = body.email.trim();
+  }
+
+  const fields = {
+    status: DEFAULT_STATUS,
+    latlong,
+    location,
+    text,
+    tags,
+  };
+  if (email) {
+    fields.email = email;
+  }
+  return fields;
+}
+
+function buildCommentsResponse(records) {
+  const tagsListComment = records.find((c) => c?.fields?.id === TAGS_LIST_COMMENT_ID);
+  if (!tagsListComment || !Array.isArray(tagsListComment.fields.tags)) {
+    const err = new Error('Failed to load comments');
+    err.statusCode = 502;
+    throw err;
+  }
+
+  const comments = records
+    .filter((c) => c?.fields?.status !== 'Resolvida')
+    .filter((c) => c?.fields?.latlong !== undefined)
+    .map(stripPrivateFields);
+
+  return {
+    comments,
+    tagsList: tagsListComment.fields.tags,
+  };
+}
+
+async function handleGet(res) {
+  const records = await fetchAirtableTable(COMMENTS_TABLE_NAME);
+  const payload = buildCommentsResponse(records);
+  sendJson(res, 200, payload, { 'Cache-Control': GET_CACHE_CONTROL });
+}
+
+async function handlePost(req, res) {
+  const body = readJsonBody(req);
+  const fields = validateCommentPayload(body);
+  await createAirtableRecord(COMMENTS_TABLE_NAME, fields);
+  sendJson(res, 201, { ok: true }, { 'Cache-Control': 'no-store' });
+}
+
+module.exports = async function commentsHandler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      await handleGet(res);
+      return;
+    }
+    if (req.method === 'POST') {
+      await handlePost(req, res);
+      return;
+    }
+    methodNotAllowed(res, 'GET, POST');
+  } catch (err) {
+    sendError(res, err);
+  }
+};

--- a/api/airtable/metadata.js
+++ b/api/airtable/metadata.js
@@ -1,0 +1,18 @@
+const { fetchAirtableTable, sendJson, sendError, methodNotAllowed } = require('../_lib/airtable');
+
+const METADATA_TABLE_NAME = 'Metadata';
+const CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';
+
+module.exports = async function metadataHandler(req, res) {
+  if (req.method !== 'GET') {
+    methodNotAllowed(res, 'GET');
+    return;
+  }
+
+  try {
+    const records = await fetchAirtableTable(METADATA_TABLE_NAME);
+    sendJson(res, 200, records, { 'Cache-Control': CACHE_CONTROL });
+  } catch (err) {
+    sendError(res, err);
+  }
+};

--- a/craco.config.js
+++ b/craco.config.js
@@ -35,31 +35,9 @@ module.exports = {
   ],
   webpack: {
     configure: (webpackConfig) => {
-      // Add rule to handle TypeScript files in node_modules
-      webpackConfig.module.rules.push({
-        test: /\.tsx?$/,
-        include: /node_modules\/(mapbox-pmtiles|pmtiles)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              ['@babel/preset-env', { targets: { node: 'current' } }],
-              [
-                '@babel/preset-typescript',
-                {
-                  allowDeclareFields: true,
-                  onlyRemoveTypeImports: true,
-                },
-              ],
-            ],
-            plugins: ['@babel/plugin-proposal-class-properties'],
-          },
-        },
-      });
-
       // CRA's source-map-loader walks node_modules JS. zipson and @firebase/auth
       // ship maps that point at files not in the npm package (ENOENT spam in
-      // yarn start / vercel dev). mapbox-pmtiles is excluded for the same reason.
+      // yarn start / vercel dev).
       const sourceMapLoaderRule = webpackConfig.module.rules.find(
         (rule) => typeof rule.loader === 'string' && rule.loader.includes('source-map-loader')
       );
@@ -70,7 +48,6 @@ module.exports = {
           : [];
         sourceMapLoaderRule.exclude = [
           ...existingExclude,
-          /node_modules\/(mapbox-pmtiles|pmtiles)/,
           /[\\/]node_modules[\\/]zipson[\\/]/,
           /[\\/]node_modules[\\/]@firebase[\\/]/,
         ];

--- a/e2e/apis.spec.ts
+++ b/e2e/apis.spec.ts
@@ -3,6 +3,7 @@
  * (no browser, no `yarn start`). Run: `yarn e2e e2e/apis.spec.ts`
  *
  * Optional env (same names as CRA): when unset, Mapbox / ORS / GraphHopper / Google tests skip.
+ * Airtable function smoke: set AIRTABLE_API_SMOKE_BASE_URL (no POST; does not create comments).
  * Keys restricted to browser referrers may fail here; use a server-friendly token or run locally.
  *
  * When a provider is down (connection errors or HTTP 5xx/429), tests skip with warnings in the
@@ -37,6 +38,8 @@ const OVERPASS_TRY_MS = 35_000;
 const VALHALLA_BASE_URL = 'https://valhalla1.openstreetmap.de/route';
 const VALHALLA_TRY_MS = 30_000;
 const VALHALLA_RETRIES = 3;
+
+const airtableSmokeBase = process.env.AIRTABLE_API_SMOKE_BASE_URL?.replace(/\/$/, '');
 
 const mapboxToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 const orsKey = process.env.REACT_APP_OPENROUTESERVICE_API_KEY;
@@ -295,6 +298,44 @@ test.describe('Google Maps JS bootstrap (requires REACT_APP_GOOGLE_PLACES_API_KE
       skipIfHttpOutage(testInfo, 'Google Maps', endpoint, res.status(), text);
       expect(res.ok(), text).toBeTruthy();
       expect(text).toContain('google.maps');
+    });
+  });
+});
+
+test.describe('CicloMapa Airtable proxy (requires AIRTABLE_API_SMOKE_BASE_URL)', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !airtableSmokeBase,
+      'Set AIRTABLE_API_SMOKE_BASE_URL to run deployed Airtable function checks'
+    );
+  });
+
+  test('GET /api/airtable/metadata returns records', async ({ request }, testInfo) => {
+    const endpoint = `${airtableSmokeBase}/api/airtable/metadata`;
+    await withApiOutageSkip(testInfo, 'Airtable metadata', endpoint, async () => {
+      const res = await request.get(endpoint);
+      const text = await res.text();
+      skipIfHttpOutage(testInfo, 'Airtable metadata', endpoint, res.status(), text);
+      expect(res.ok(), text).toBeTruthy();
+      const data = JSON.parse(text);
+      expect(Array.isArray(data)).toBe(true);
+    });
+  });
+
+  test('GET /api/airtable/comments returns tags and no emails', async ({ request }, testInfo) => {
+    const endpoint = `${airtableSmokeBase}/api/airtable/comments`;
+    await withApiOutageSkip(testInfo, 'Airtable comments', endpoint, async () => {
+      const res = await request.get(endpoint);
+      const text = await res.text();
+      skipIfHttpOutage(testInfo, 'Airtable comments', endpoint, res.status(), text);
+      expect(res.ok(), text).toBeTruthy();
+      const data = JSON.parse(text);
+      expect(Array.isArray(data.tagsList)).toBe(true);
+      expect(Array.isArray(data.comments)).toBe(true);
+      for (const comment of data.comments) {
+        expect(comment.fields?.email).toBeUndefined();
+      }
+      expect(JSON.stringify(data)).not.toMatch(/"email"\s*:/);
     });
   });
 });

--- a/inspect-pmtiles.mjs
+++ b/inspect-pmtiles.mjs
@@ -1,0 +1,41 @@
+import { PMTiles, FetchSource } from 'pmtiles';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
+
+const url = 'https://ciclomapa.s3.us-east-1.amazonaws.com/pmtiles/brazil-poi.pmtiles';
+const p = new PMTiles(url);
+
+const header = await p.getHeader();
+console.log('header:', JSON.stringify(header, null, 2));
+
+// Fortaleza, Brazil (DEFAULT_AREA) ~ -3.7327, -38.5267
+function lngLatToTile(lng, lat, zoom) {
+  const latRad = (lat * Math.PI) / 180;
+  const n = 2 ** zoom;
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x, y, z: zoom };
+}
+
+const zoom = 11;
+const { x, y, z } = lngLatToTile(-38.5267, -3.7327, zoom);
+console.log(`Fetching tile z=${z} x=${x} y=${y}`);
+
+const tileResult = await p.getZxy(z, x, y);
+if (!tileResult) {
+  console.log('No tile data found at this location/zoom.');
+  process.exit(0);
+}
+
+const tile = new VectorTile(new Protobuf(tileResult.data));
+console.log('Layers in tile:', Object.keys(tile.layers));
+
+for (const layerName of Object.keys(tile.layers)) {
+  const layer = tile.layers[layerName];
+  console.log(`\nLayer "${layerName}" - ${layer.length} features`);
+  const sample = Math.min(layer.length, 5);
+  for (let i = 0; i < sample; i++) {
+    const feat = layer.feature(i);
+    console.log(`  feature[${i}] type=${feat.type} properties=`, feat.properties);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "idb-keyval": "^6.2.1",
     "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",
-    "mapbox-gl": "^3.19.1",
+    "mapbox-gl": "^3.21.0",
     "mapbox-pmtiles": "^1.0.54",
     "osmtogeojson": "^3.0.0-beta.4",
     "pako": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",
     "mapbox-gl": "^3.21.0",
-    "mapbox-pmtiles": "^1.0.54",
     "osmtogeojson": "^3.0.0-beta.4",
     "pako": "^2.0.3",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "e2e": "playwright test",
     "e2e:apis": "playwright test e2e/apis.spec.ts",
     "e2e:ui": "playwright test --ui",
-    "lint": "eslint src/",
+    "lint": "eslint src/ api/",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "format": "prettier --write \"{src,scripts,docs}/**/*.{js,jsx,ts,tsx,json,css,less,md}\"",
-    "format:check": "prettier --check \"{src,scripts,docs}/**/*.{js,jsx,ts,tsx,json,css,less,md}\"",
+    "format": "prettier --write \"{src,scripts,docs,api}/**/*.{js,jsx,ts,tsx,json,css,less,md}\"",
+    "format:check": "prettier --check \"{src,scripts,docs,api}/**/*.{js,jsx,ts,tsx,json,css,less,md}\"",
     "eject": "react-scripts eject",
     "predeploy": "yarn run build",
     "deploy": "gh-pages -d build",
@@ -120,6 +120,10 @@
       "prettier --write"
     ],
     "scripts/**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "api/**/*.{js,ts}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/scripts/pmtiles-builds.json
+++ b/scripts/pmtiles-builds.json
@@ -68,7 +68,14 @@
       "output": "brazil-poi.pmtiles",
       "areas": ["Brazil"],
       "includePoi": true,
-      "description": "Brazil — cycle layers + POIs"
+      "description": "Brazil — cycle layers + POIs (non-standard)"
+    },
+    {
+      "id": "brazil-spain-poi",
+      "output": "brazil-spain-poi.pmtiles",
+      "areas": ["Brazil", "Spain"],
+      "includePoi": true,
+      "description": "Brazil + Spain — cycle layers + POIs (non-standard)"
     }
   ]
 }

--- a/src/AirtableDatabase.js
+++ b/src/AirtableDatabase.js
@@ -1,19 +1,4 @@
 import { removeAccents } from './utils/utils.js';
-import { API_TYPES, trackCall } from './dev/apiTracker.js';
-
-const AIRTABLE_API_KEY = process.env.REACT_APP_AIRTABLE_API_KEY;
-const AIRTABLE_BASE_ID = process.env.REACT_APP_AIRTABLE_BASE_ID;
-
-const COMMENTS_TABLE_NAME = 'Comments';
-const METADATA_TABLE_NAME = 'Metadata';
-
-const TAGS_LIST_COMMENT_ID = 44;
-
-const debugStyles = {
-  blue: 'color: lightblue;',
-  gray: 'color: gray;',
-  important: 'font-size: 1.2em;',
-};
 
 class AirtableDatabase {
   /**
@@ -40,103 +25,39 @@ class AirtableDatabase {
     return hit?.fields ?? null;
   }
 
-  async fetchTable(tableName, view, offset, accumulator = []) {
-    if (!AIRTABLE_API_KEY) {
-      console.error('No AIRTABLE_API_KEY found');
-      return;
-    }
-
-    trackCall({ api: API_TYPES.AIRTABLE_READ, details: `${tableName}${view ? `/${view}` : ''}` });
-
-    let queryUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${tableName}?`;
-    if (view) {
-      queryUrl += `&view=${view}`;
-    }
-    if (offset) {
-      queryUrl += `&offset=${offset}`;
-    }
-    const response = await fetch(queryUrl, {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-      },
-    });
-
-    const data = await response.json();
-
-    if (data.records && data.records.length > 0) {
-      let accumulated = data.records;
-
-      accumulated = accumulated.concat(accumulator);
-
-      if (data.offset) {
-        console.debug(
-          `%cfetchTable(${tableName}/${view}): offset detected, recursing...`,
-          debugStyles.blue
-        );
-        return this.fetchTable(tableName, view, data.offset, accumulated);
-      } else {
-        console.debug(
-          `%cfetchTable(${tableName}/${view}): end of pagination, returning.`,
-          debugStyles.blue
-        );
-        return accumulated;
+  async request(path, options) {
+    const response = await fetch(path, options);
+    if (!response.ok) {
+      let message = 'Airtable request failed';
+      try {
+        const body = await response.json();
+        if (body && typeof body.error === 'string' && body.error.trim()) {
+          message = body.error;
+        }
+      } catch {
+        // keep generic message
       }
-    } else {
-      console.warn(`%cfetchTable(${tableName}/${view}): zero records`, debugStyles.blue);
+      const err = new Error(message);
+      err.status = response.status;
+      throw err;
     }
+    return response.json();
   }
 
-  async post(tableName, data) {
-    trackCall({ api: API_TYPES.AIRTABLE_WRITE, details: tableName });
-
-    let queryUrl = `https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${tableName}`;
-
-    await fetch(queryUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-      },
-      body: JSON.stringify(data),
-    }).then((res) => {
-      console.log('Request complete! response:', res);
-    });
+  async getMetadata() {
+    return this.request('/api/airtable/metadata');
   }
 
   async getComments() {
-    let comments = await this.fetchTable(COMMENTS_TABLE_NAME);
-
-    if (comments) {
-      // This special comment has a list of all possible tags
-      const tagsListComment = comments.filter((c) => c.fields.id === TAGS_LIST_COMMENT_ID)[0];
-
-      if (tagsListComment) {
-        const tagsList = tagsListComment.fields.tags;
-
-        // Filter out solved comments
-        // @todo filter them when fetching the table, to improve performance
-        comments = comments.filter((c) => c.fields.status !== 'Resolvida');
-
-        // Ignore if there are comments without latlong
-        comments = comments.filter((c) => c.fields.latlong !== undefined);
-
-        return {
-          comments,
-          tagsList,
-        };
-      } else {
-        console.error('getComments(): Error retrieving tags list');
-      }
-    }
-  }
-
-  async getMetadata(city) {
-    return await this.fetchTable(METADATA_TABLE_NAME);
+    return this.request('/api/airtable/comments');
   }
 
   async create(fields) {
-    return await this.post(COMMENTS_TABLE_NAME, { records: [{ fields }] });
+    return this.request('/api/airtable/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(fields),
+    });
   }
 }
 

--- a/src/AnalyticsSidebar.js
+++ b/src/AnalyticsSidebar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Popover, Button, Select, Checkbox } from 'antd';
+import { Popover, Button, Select, Checkbox, Dropdown } from 'antd';
 
 import './AnalyticsSidebar.css';
 
@@ -20,6 +20,7 @@ import {
   HiX as IconClose,
   HiInformationCircle as IconInfo,
   HiDownload as IconDownload,
+  HiDotsVertical as IconMore,
 } from 'react-icons/hi';
 
 import { HiMiniCheckBadge as IconVerified } from 'react-icons/hi2';
@@ -236,14 +237,50 @@ class AnalyticsSidebar extends Component {
               <h2 className="my-0">Métricas</h2>
             </div>
 
-            <Button
-              type="text"
-              shape="circle"
-              className="text-xl -mr-2 text-inherit"
-              icon={<IconClose />}
-              onClick={() => this.props.toggle(false)}
-              aria-label="Fechar painel de métricas"
-            />
+            <div className="flex items-center -mr-2">
+              {this.props.downloadData && (
+                <Dropdown
+                  trigger={['click']}
+                  placement="bottomRight"
+                  menu={{
+                    items: [
+                      {
+                        key: 'download',
+                        icon: <IconDownload className="mt-0.5 self-start" />,
+                        label: (
+                          <div className="max-w-[220px] py-0.5 leading-snug">
+                            <div>Baixar GeoJSON</div>
+                            <div className="mt-0.5 text-xs font-normal opacity-60 whitespace-normal">
+                              Dados da infraestrutura cicloviária desta cidade para uso em seus
+                              próprios projetos e análises.
+                            </div>
+                          </div>
+                        ),
+                      },
+                    ],
+                    onClick: ({ key }) => {
+                      if (key === 'download') this.props.downloadData();
+                    },
+                  }}
+                >
+                  <Button
+                    type="text"
+                    shape="circle"
+                    className="text-xl text-inherit"
+                    icon={<IconMore />}
+                    aria-label="Mais opções"
+                  />
+                </Dropdown>
+              )}
+              <Button
+                type="text"
+                shape="circle"
+                className="text-xl text-inherit"
+                icon={<IconClose />}
+                onClick={() => this.props.toggle(false)}
+                aria-label="Fechar painel de métricas"
+              />
+            </div>
           </div>
 
           {this.props.location && (
@@ -556,19 +593,6 @@ class AnalyticsSidebar extends Component {
                   )
               )}
           </Section>
-
-          {this.props.downloadData && (
-            <Section title="Download dados">
-              <p className="text-xs opacity-50">
-                Baixe os dados da infraestrutura cicloviária desta cidade para uso em seus próprios
-                projetos e análises.
-              </p>
-              <Button onClick={this.props.downloadData} size="small" className="opacity-70">
-                <IconDownload className="inline-block" />
-                {this.props.location.split(',')[0]}.geojson
-              </Button>
-            </Section>
-          )}
         </div>
       </div>
     );

--- a/src/AnalyticsSidebar.js
+++ b/src/AnalyticsSidebar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Popover, Button, Select, Checkbox, Dropdown } from 'antd';
+import { Popover, Button, Select, Checkbox, Dropdown, Space } from 'antd';
 
 import './AnalyticsSidebar.css';
 
@@ -19,6 +19,7 @@ import {
 import {
   HiX as IconClose,
   HiInformationCircle as IconInfo,
+  HiOutlineRefresh as IconUpdate,
   HiDownload as IconDownload,
   HiDotsVertical as IconMore,
 } from 'react-icons/hi';
@@ -31,6 +32,7 @@ import {
   LENGTH_COUNTED_LAYER_IDS,
 } from './config/constants.js';
 import { THIN_SPACE, appendKmUnit } from './utils/routeUtils.js';
+import { timeSince } from './utils/utils.js';
 
 const PIE_CHART_WIDTH_PX = 207;
 const nullableNumber = PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]);
@@ -231,102 +233,103 @@ class AnalyticsSidebar extends Component {
           this.props.open ? 'analytics-sidebar--open' : 'analytics-sidebar--closed'
         }`}
       >
-        <div className="px-5 pb-10">
-          <div className="flex w-full justify-between items-center pt-2 mt-1">
-            <div className="flex items-center">
-              <h2 className="my-0">Métricas</h2>
-            </div>
+        <div className="px-5 pb-5 flex flex-col min-h-full">
+          <div className="flex-1">
+            <div className="flex w-full justify-between items-center pt-2 mt-1">
+              <div className="flex items-center">
+                <h2 className="my-0">Métricas</h2>
+              </div>
 
-            <div className="flex items-center -mr-2">
-              {this.props.downloadData && (
-                <Dropdown
-                  trigger={['click']}
-                  placement="bottomRight"
-                  menu={{
-                    items: [
-                      {
-                        key: 'download',
-                        icon: <IconDownload className="mt-0.5 self-start" />,
-                        label: (
-                          <div className="max-w-[220px] py-0.5 leading-snug">
-                            <div>Baixar GeoJSON</div>
-                            <div className="mt-0.5 text-xs font-normal opacity-60 whitespace-normal">
-                              Dados da infraestrutura cicloviária desta cidade para uso em seus
-                              próprios projetos e análises.
+              <div className="flex items-center -mr-2">
+                {this.props.downloadData && (
+                  <Dropdown
+                    trigger={['click']}
+                    placement="bottomRight"
+                    menu={{
+                      items: [
+                        {
+                          key: 'download',
+                          icon: <IconDownload className="mt-0.5 self-start" />,
+                          label: (
+                            <div className="max-w-[220px] py-0.5 leading-snug">
+                              <div>Baixar GeoJSON</div>
+                              <div className="mt-0.5 text-xs font-normal opacity-60 whitespace-normal">
+                                Dados da infraestrutura cicloviária desta cidade para uso em seus
+                                próprios projetos e análises.
+                              </div>
                             </div>
-                          </div>
-                        ),
+                          ),
+                        },
+                      ],
+                      onClick: ({ key }) => {
+                        if (key === 'download') this.props.downloadData();
                       },
-                    ],
-                    onClick: ({ key }) => {
-                      if (key === 'download') this.props.downloadData();
-                    },
-                  }}
-                >
-                  <Button
-                    type="text"
-                    shape="circle"
-                    className="text-xl text-inherit"
-                    icon={<IconMore />}
-                    aria-label="Mais opções"
-                  />
-                </Dropdown>
-              )}
-              <Button
-                type="text"
-                shape="circle"
-                className="text-xl text-inherit"
-                icon={<IconClose />}
-                onClick={() => this.props.toggle(false)}
-                aria-label="Fechar painel de métricas"
-              />
+                    }}
+                  >
+                    <Button
+                      type="text"
+                      shape="circle"
+                      className="text-xl text-inherit"
+                      icon={<IconMore />}
+                      aria-label="Mais opções"
+                    />
+                  </Dropdown>
+                )}
+                <Button
+                  type="text"
+                  shape="circle"
+                  className="text-xl text-inherit"
+                  icon={<IconClose />}
+                  onClick={() => this.props.toggle(false)}
+                  aria-label="Fechar painel de métricas"
+                />
+              </div>
             </div>
-          </div>
 
-          {this.props.location && (
-            <>
-              <div className="mt-3 text-3xl leading-snug font-heading-display uppercase">
-                {this.props.location.split(',')[0]}
-              </div>
-              <div className="mb-2 mt-2 text-lg tracking-tight opacity-50 leading-tight">
-                {this.props.location.split(',')[1] && `${this.props.location.split(',')[1]}`}
-              </div>
-            </>
-          )}
+            {this.props.location && (
+              <>
+                <div className="mt-3 text-3xl leading-snug font-heading-display uppercase">
+                  {this.props.location.split(',')[0]}
+                </div>
+                <div className="mb-2 mt-2 text-lg tracking-tight opacity-50 leading-tight">
+                  {this.props.location.split(',')[1] && `${this.props.location.split(',')[1]}`}
+                </div>
+              </>
+            )}
 
-          {this.props.cityMetadata && this.props.cityMetadata.pnb_total !== undefined && (
-            <Section
-              title="PNB"
-              link={'https://itdpbrasil.org/pnb/'}
-              year={this.props.cityMetadata.pnb_year}
-              description={
-                <>
-                  <p>
-                    O People Near Bike (pessoas próximas a bicicleta) é apurado anualmente pelo ITDP
-                    Brasil para avaliar as políticas de ciclomobilidade com maior efetividade e
-                    indica o percentual de pessoas que moram a até 300 metros de ciclovias e
-                    ciclofaixas.
-                  </p>
-                </>
-              }
-            >
-              <BigNum>{this.props.cityMetadata.pnb_total + '%'}</BigNum>
+            {this.props.cityMetadata && this.props.cityMetadata.pnb_total !== undefined && (
+              <Section
+                title="PNB"
+                link={'https://itdpbrasil.org/pnb/'}
+                year={this.props.cityMetadata.pnb_year}
+                description={
+                  <>
+                    <p>
+                      O People Near Bike (pessoas próximas a bicicleta) é apurado anualmente pelo
+                      ITDP Brasil para avaliar as políticas de ciclomobilidade com maior efetividade
+                      e indica o percentual de pessoas que moram a até 300 metros de ciclovias e
+                      ciclofaixas.
+                    </p>
+                  </>
+                }
+              >
+                <BigNum>{this.props.cityMetadata.pnb_total + '%'}</BigNum>
 
-              {this.props.cityMetadata.pnb_black_women !== undefined && (
-                <DataLine
-                  name="Mulheres negras"
-                  length={this.props.cityMetadata.pnb_black_women}
-                  unit="%"
-                />
-              )}
-              {this.props.cityMetadata.pnb_women_less_one_salary !== undefined && (
-                <DataLine
-                  name="Mulheres renda até 1 SM"
-                  length={this.props.cityMetadata.pnb_women_less_one_salary}
-                  unit="%"
-                />
-              )}
-              {/* {
+                {this.props.cityMetadata.pnb_black_women !== undefined && (
+                  <DataLine
+                    name="Mulheres negras"
+                    length={this.props.cityMetadata.pnb_black_women}
+                    unit="%"
+                  />
+                )}
+                {this.props.cityMetadata.pnb_women_less_one_salary !== undefined && (
+                  <DataLine
+                    name="Mulheres renda até 1 SM"
+                    length={this.props.cityMetadata.pnb_women_less_one_salary}
+                    unit="%"
+                  />
+                )}
+                {/* {
                                 this.props.cityMetadata.pnb_2024!==undefined &&
                                 <DataLine
                                     name="2024"
@@ -383,216 +386,265 @@ class AnalyticsSidebar extends Component {
                                 />
                             } */}
 
-              {pnbEvolutionData.length >= 2 && (
-                <div>
-                  <div className="w-full mt-3" style={{ height: 124, marginBottom: -24 }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart
-                        data={pnbEvolutionData}
-                        margin={{
-                          right: 12,
-                          left: 12,
-                          top: 1,
-                        }}
-                      >
-                        <XAxis
-                          dataKey="year"
-                          tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
-                          ticks={['2018', '2020', '2022', '2024']}
-                          interval={'preserveStartEnd'}
-                          margin={{ left: 8, right: 8 }}
-                          axisLine={false}
-                          tickLine={false}
-                        />
-                        <YAxis
-                          // domain={['dataMin', 'dataMax']}
-                          domain={[0, 50]}
-                          ticks={[15, 30, 50]}
-                          interval={'preserveEnd'}
-                          tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
-                          axisLine={false}
-                          tickLine={false}
-                          mirror={true}
-                        />
-                        <CartesianGrid
-                          stroke="currentColor"
-                          strokeOpacity={0.2}
-                          strokeWidth={0.5}
-                        />
-                        <RechartsTooltip {...pnbLineChartTooltipProps} />
-                        <Line
-                          type="monotone"
-                          dataKey="value"
-                          stroke={isDarkMode ? '#a8c957' : '#386641'}
-                          strokeWidth={2}
-                          dot={{ r: 1 }}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
+                {pnbEvolutionData.length >= 2 && (
+                  <div>
+                    <div className="w-full mt-3" style={{ height: 124, marginBottom: -24 }}>
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart
+                          data={pnbEvolutionData}
+                          margin={{
+                            right: 12,
+                            left: 12,
+                            top: 1,
+                          }}
+                        >
+                          <XAxis
+                            dataKey="year"
+                            tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
+                            ticks={['2018', '2020', '2022', '2024']}
+                            interval={'preserveStartEnd'}
+                            margin={{ left: 8, right: 8 }}
+                            axisLine={false}
+                            tickLine={false}
+                          />
+                          <YAxis
+                            // domain={['dataMin', 'dataMax']}
+                            domain={[0, 50]}
+                            ticks={[15, 30, 50]}
+                            interval={'preserveEnd'}
+                            tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
+                            axisLine={false}
+                            tickLine={false}
+                            mirror={true}
+                          />
+                          <CartesianGrid
+                            stroke="currentColor"
+                            strokeOpacity={0.2}
+                            strokeWidth={0.5}
+                          />
+                          <RechartsTooltip {...pnbLineChartTooltipProps} />
+                          <Line
+                            type="monotone"
+                            dataKey="value"
+                            stroke={isDarkMode ? '#a8c957' : '#386641'}
+                            strokeWidth={2}
+                            dot={{ r: 1 }}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
                   </div>
-                </div>
-              )}
-            </Section>
-          )}
+                )}
+              </Section>
+            )}
 
-          {this.props.cityMetadata && this.props.cityMetadata.ideciclo !== undefined && (
+            {this.props.cityMetadata && this.props.cityMetadata.ideciclo !== undefined && (
+              <Section
+                title="IDECiclo"
+                link="https://www.ideciclo.org/"
+                year={this.props.cityMetadata.ideciclo_year}
+                description={
+                  <>
+                    <p>
+                      O Índice de Desenvolvimento Cicloviário (IDECICLO) tem como objetivo avaliar
+                      qualitativamente a infraestrutura cicloviária da cidade de forma objetiva e
+                      replicável de modo que haja acompanhamento da evolução dos parâmetros para uma
+                      comparação entre infraestruturas e entre cidades, de maneira a construir uma
+                      séria histórica.
+                    </p>
+                    <p>
+                      O IDECICLO faz uma avaliação local de cada estrutura e pondera esta sob a
+                      malha total da cidade e com as velocidades máximas das vias que estão sendo
+                      inseridas, podendo ser um índice comparativo entre cidades e entre estruturas.
+                    </p>
+                    <p>Escala: de 0 a 1.</p>
+                  </>
+                }
+              >
+                <BigNum>{this.props.cityMetadata.ideciclo}</BigNum>
+              </Section>
+            )}
+
             <Section
-              title="IDECiclo"
-              link="https://www.ideciclo.org/"
-              year={this.props.cityMetadata.ideciclo_year}
+              title="Vias"
               description={
                 <>
                   <p>
-                    O Índice de Desenvolvimento Cicloviário (IDECICLO) tem como objetivo avaliar
-                    qualitativamente a infraestrutura cicloviária da cidade de forma objetiva e
-                    replicável de modo que haja acompanhamento da evolução dos parâmetros para uma
-                    comparação entre infraestruturas e entre cidades, de maneira a construir uma
-                    séria histórica.
+                    As extensões totais das vias são calculadas automaticamente com base nos dados
+                    do OpenStreetMap.
                   </p>
                   <p>
-                    O IDECICLO faz uma avaliação local de cada estrutura e pondera esta sob a malha
-                    total da cidade e com as velocidades máximas das vias que estão sendo inseridas,
-                    podendo ser um índice comparativo entre cidades e entre estruturas.
+                    Para vias que tem estrutura dos dois lados nós desenvolvemos um método que
+                    automaticamente detecta estes casos e remove esta contagem dupla do total.
                   </p>
-                  <p>Escala: de 0 a 1.</p>
+                  <OpenStreetMapDisclaimer />
                 </>
               }
             >
-              <BigNum>{this.props.cityMetadata.ideciclo}</BigNum>
-            </Section>
-          )}
+              {this.props.debugMode && strategiesDropdown}
 
-          <Section
-            title="Vias"
-            description={
-              <>
-                <p>
-                  As extensões totais das vias são calculadas automaticamente com base nos dados do
-                  OpenStreetMap.
-                </p>
-                <p>
-                  Para vias que tem estrutura dos dois lados nós desenvolvemos um método que
-                  automaticamente detecta estes casos e remove esta contagem dupla do total.
-                </p>
-                <OpenStreetMapDisclaimer />
-              </>
-            }
-          >
-            {this.props.debugMode && strategiesDropdown}
+              <div className="relative">
+                <PieChart width={PIE_CHART_WIDTH_PX} height={PIE_CHART_WIDTH_PX}>
+                  <defs>{this.generatePatterns(layers)}</defs>
+                  <Pie
+                    data={vias.pieSlices}
+                    dataKey="value"
+                    cx={'50%'}
+                    cy={'50%'}
+                    innerRadius={90}
+                    outerRadius={100}
+                    paddingAngle={vias.hasPieBreakdown ? 4 : 0}
+                    strokeWidth={0}
+                    startAngle={90}
+                    endAngle={450}
+                    cornerRadius="50%"
+                  />
+                </PieChart>
 
-            <div className="relative">
-              <PieChart width={PIE_CHART_WIDTH_PX} height={PIE_CHART_WIDTH_PX}>
-                <defs>{this.generatePatterns(layers)}</defs>
-                <Pie
-                  data={vias.pieSlices}
-                  dataKey="value"
-                  cx={'50%'}
-                  cy={'50%'}
-                  innerRadius={90}
-                  outerRadius={100}
-                  paddingAngle={vias.hasPieBreakdown ? 4 : 0}
-                  strokeWidth={0}
-                  startAngle={90}
-                  endAngle={450}
-                  cornerRadius="50%"
-                />
-              </PieChart>
-
-              <div
-                className="absolute top-0 w-full flex flex-col items-center justify-center"
-                style={{ height: `${PIE_CHART_WIDTH_PX}px`, width: `${PIE_CHART_WIDTH_PX}px` }}
-              >
-                {lengths && vias.rawTotal > 0 ? (
-                  <>
-                    <span className="inline-flex flex-col items-center cursor-default">
-                      <span className="tracking-wides text-xs">TOTAL</span>
-                      <span className="font-regular">
-                        <span className="text-4xl tracking-tighter">
-                          {vias.effectiveTotal.toFixed(1)}
+                <div
+                  className="absolute top-0 w-full flex flex-col items-center justify-center"
+                  style={{ height: `${PIE_CHART_WIDTH_PX}px`, width: `${PIE_CHART_WIDTH_PX}px` }}
+                >
+                  {lengths && vias.rawTotal > 0 ? (
+                    <>
+                      <span className="inline-flex flex-col items-center cursor-default">
+                        <span className="tracking-wides text-xs">TOTAL</span>
+                        <span className="font-regular">
+                          <span className="text-4xl tracking-tighter">
+                            {vias.effectiveTotal.toFixed(1)}
+                          </span>
+                          <span className="text-sm">{`${THIN_SPACE}km`}</span>
                         </span>
-                        <span className="text-sm">{`${THIN_SPACE}km`}</span>
                       </span>
-                    </span>
-                    {ENABLE_OFFICIAL_CITY_HALL_METRICS_COMPARISON &&
-                      this.props.cityMetadata &&
-                      this.props.cityMetadata.alianca_2025 !== undefined &&
-                      this.props.cityMetadata.alianca_2025 !== null && (
-                        <>
-                          {/* <span className="tracking-widest mt-2">OFICIAL</span> */}
-                          <Popover
-                            placement="left"
-                            arrow={{ pointAtCenter: true }}
-                            content={
-                              <div
-                                className="flex flex-col gap-3 leading-normal"
-                                style={{ width: 320 }}
-                              >
-                                <h3 className="text-lg flex items-center gap-1">
-                                  <IconVerified className="inline-block text-green-300 text-xl" />{' '}
-                                  Dado Oficial da Prefeitura
-                                </h3>
-                                <p>
-                                  Quilometragem total de ciclovias e ciclofaixas divulgada como dado
-                                  oficial da Prefeitura com base no levantamento anual da Aliança
-                                  Bike. Última atualização: julho de 2025.
-                                </p>
-                                <OfficialDisclaimer />
-                                <Button
-                                  type="primary"
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  href="https://aliancabike.org.br/dados-do-setor/ciclovias-e-ciclofaixas/"
+                      {ENABLE_OFFICIAL_CITY_HALL_METRICS_COMPARISON &&
+                        this.props.cityMetadata &&
+                        this.props.cityMetadata.alianca_2025 !== undefined &&
+                        this.props.cityMetadata.alianca_2025 !== null && (
+                          <>
+                            {/* <span className="tracking-widest mt-2">OFICIAL</span> */}
+                            <Popover
+                              placement="left"
+                              arrow={{ pointAtCenter: true }}
+                              content={
+                                <div
+                                  className="flex flex-col gap-3 leading-normal"
+                                  style={{ width: 320 }}
                                 >
-                                  Saiba mais
-                                </Button>
-                              </div>
-                            }
-                          >
-                            <span className="flex items-center decoration-dotted tracking-tight gap-0.5">
-                              <IconVerified className="inline-block opacity-50" />
-                              <div className="flex items-center items-baseline opacity-70">
-                                {appendKmUnit(
-                                  Number(this.props.cityMetadata.alianca_2025).toFixed(1)
-                                )}
-                              </div>
-                              {/* <IconInfo /> */}
-                            </span>
-                          </Popover>
-                        </>
-                      )}
-                  </>
-                ) : (
-                  <span className="opacity-50">Sem dados</span>
-                )}
+                                  <h3 className="text-lg flex items-center gap-1">
+                                    <IconVerified className="inline-block text-green-300 text-xl" />{' '}
+                                    Dado Oficial da Prefeitura
+                                  </h3>
+                                  <p>
+                                    Quilometragem total de ciclovias e ciclofaixas divulgada como
+                                    dado oficial da Prefeitura com base no levantamento anual da
+                                    Aliança Bike. Última atualização: julho de 2025.
+                                  </p>
+                                  <OfficialDisclaimer />
+                                  <Button
+                                    type="primary"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    href="https://aliancabike.org.br/dados-do-setor/ciclovias-e-ciclofaixas/"
+                                  >
+                                    Saiba mais
+                                  </Button>
+                                </div>
+                              }
+                            >
+                              <span className="flex items-center decoration-dotted tracking-tight gap-0.5">
+                                <IconVerified className="inline-block opacity-50" />
+                                <div className="flex items-center items-baseline opacity-70">
+                                  {appendKmUnit(
+                                    Number(this.props.cityMetadata.alianca_2025).toFixed(1)
+                                  )}
+                                </div>
+                                {/* <IconInfo /> */}
+                              </span>
+                            </Popover>
+                          </>
+                        )}
+                    </>
+                  ) : (
+                    <span className="opacity-50">Sem dados</span>
+                  )}
+                </div>
               </div>
-            </div>
 
-            <div className="mt-2">
-              {vias.infraLayers.map((l) => (
-                <ViaDataRow
-                  key={l.id}
-                  layer={l}
-                  length={lengths && lengths[l.id]}
-                  rawTotal={vias.rawTotal}
-                  effectiveTotal={vias.effectiveTotal}
-                  included={this.state.lengthsInclude[l.id]}
-                  onToggleInclude={() => this.toggleLengthsInclude(l.id)}
-                />
-              ))}
-            </div>
-          </Section>
+              <div className="mt-2">
+                {vias.infraLayers.map((l) => (
+                  <ViaDataRow
+                    key={l.id}
+                    layer={l}
+                    length={lengths && lengths[l.id]}
+                    rawTotal={vias.rawTotal}
+                    effectiveTotal={vias.effectiveTotal}
+                    included={this.state.lengthsInclude[l.id]}
+                    onToggleInclude={() => this.toggleLengthsInclude(l.id)}
+                  />
+                ))}
+              </div>
+            </Section>
 
-          <Section title="Pontos de interesse">
-            {layers
-              .filter((l) => l.type === 'poi' && l.name !== 'Comentários')
-              .map(
-                (l) =>
-                  lengths &&
-                  lengths[l.id] >= 0 && (
-                    <DataLine name={l.name} key={l.name} length={lengths[l.id]} />
-                  )
+            <Section title="Pontos de interesse">
+              {layers
+                .filter((l) => l.type === 'poi' && l.name !== 'Comentários')
+                .map(
+                  (l) =>
+                    lengths &&
+                    lengths[l.id] >= 0 && (
+                      <DataLine name={l.name} key={l.name} length={lengths[l.id]} />
+                    )
+                )}
+            </Section>
+          </div>
+
+          {(this.props.loading || this.props.lastUpdate) && (
+            <div className="mt-auto pt-7">
+              {this.props.loading ? (
+                <div className="flex items-center gap-1 text-xs opacity-50 hover:opacity-100 transition-opacity duration-300">
+                  Carregando dados do OpenStreetMap...
+                  <Button
+                    type="link"
+                    size="small"
+                    className="text-xs p-0 h-auto min-h-0 text-inherit opacity-70 hover:opacity-100"
+                    onClick={this.props.cancelDataLoad}
+                  >
+                    Cancelar
+                  </Button>
+                </div>
+              ) : (
+                <Popover
+                  placement="top"
+                  arrow={{ pointAtCenter: true }}
+                  content={
+                    <div style={{ maxWidth: 250 }}>
+                      <Space size="small" orientation="vertical">
+                        <div>
+                          Estes dados são uma cópia do OpenStreetMap obtida há{' '}
+                          <b>{timeSince(this.props.lastUpdate)}</b> (
+                          {this.props.lastUpdate.toLocaleString('pt-BR')}).
+                        </div>
+
+                        <Button
+                          size="small"
+                          icon={<IconUpdate />}
+                          type="primary"
+                          block
+                          onClick={this.props.forceUpdate}
+                        >
+                          Atualizar
+                        </Button>
+                      </Space>
+                    </div>
+                  }
+                >
+                  <div className="inline-flex items-center gap-1 text-xs opacity-50 hover:opacity-100 cursor transition-opacity duration-300">
+                    Atualizado há {timeSince(this.props.lastUpdate)}
+                  </div>
+                </Popover>
               )}
-          </Section>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -611,6 +663,10 @@ AnalyticsSidebar.propTypes = {
   onChangeStrategy: PropTypes.func,
   lengthCalculationStrategy: PropTypes.string,
   downloadData: PropTypes.func,
+  lastUpdate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+  loading: PropTypes.bool,
+  forceUpdate: PropTypes.func,
+  cancelDataLoad: PropTypes.func,
 };
 
 const BigNum = ({ children }) => (

--- a/src/AnalyticsSidebar.js
+++ b/src/AnalyticsSidebar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Popover, Button, Select, Checkbox, Dropdown, Space } from 'antd';
+import { Popover, Button, Select, Checkbox, Dropdown } from 'antd';
 
 import './AnalyticsSidebar.css';
 
@@ -20,6 +20,7 @@ import {
   HiX as IconClose,
   HiInformationCircle as IconInfo,
   HiOutlineRefresh as IconUpdate,
+  HiOutlineChevronDown as IconCaret,
   HiDownload as IconDownload,
   HiDotsVertical as IconMore,
 } from 'react-icons/hi';
@@ -33,6 +34,7 @@ import {
 } from './config/constants.js';
 import { THIN_SPACE, appendKmUnit } from './utils/routeUtils.js';
 import { timeSince } from './utils/utils.js';
+import { appModal } from './antdModal.js';
 
 const PIE_CHART_WIDTH_PX = 207;
 const nullableNumber = PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]);
@@ -125,6 +127,19 @@ class AnalyticsSidebar extends Component {
         /* ignore quota / private mode */
       }
       return { lengthsInclude: next };
+    });
+  }
+
+  confirmForceUpdate() {
+    appModal.confirm({
+      title: 'Atualizar dados do OpenStreetMap?',
+      content:
+        'Vamos baixar novamente os dados desta cidade. Dependendo do tamanho dela, isso pode levar alguns segundos ou até mais de um minuto.',
+      okText: 'Atualizar',
+      cancelText: 'Cancelar',
+      onOk: () => {
+        this.props.forceUpdate?.();
+      },
     });
   }
 
@@ -229,107 +244,116 @@ class AnalyticsSidebar extends Component {
     return (
       <div
         id="analyticsSidebar"
-        className={`analytics-sidebar w-64 border-l border-opacity-10 border-white h-screen overflow-y-auto glass-bg ${
+        className={`analytics-sidebar relative w-64 border-l border-opacity-10 border-white h-screen overflow-y-auto glass-bg flex flex-col ${
           this.props.open ? 'analytics-sidebar--open' : 'analytics-sidebar--closed'
         }`}
       >
-        <div className="px-5 pb-5 flex flex-col min-h-full">
-          <div className="flex-1">
-            <div className="flex w-full justify-between items-center pt-2 mt-1">
-              <div className="flex items-center">
-                <h2 className="my-0">Métricas</h2>
-              </div>
-
-              <div className="flex items-center -mr-2">
-                {this.props.downloadData && (
-                  <Dropdown
-                    trigger={['click']}
-                    placement="bottomRight"
-                    menu={{
-                      items: [
-                        {
-                          key: 'download',
-                          icon: <IconDownload className="mt-0.5 self-start" />,
-                          label: (
-                            <div className="max-w-[220px] py-0.5 leading-snug">
-                              <div>Baixar GeoJSON</div>
-                              <div className="mt-0.5 text-xs font-normal opacity-60 whitespace-normal">
-                                Dados da infraestrutura cicloviária desta cidade para uso em seus
-                                próprios projetos e análises.
-                              </div>
-                            </div>
-                          ),
-                        },
-                      ],
-                      onClick: ({ key }) => {
-                        if (key === 'download') this.props.downloadData();
-                      },
-                    }}
-                  >
-                    <Button
-                      type="text"
-                      shape="circle"
-                      className="text-xl text-inherit"
-                      icon={<IconMore />}
-                      aria-label="Mais opções"
-                    />
-                  </Dropdown>
-                )}
-                <Button
-                  type="text"
-                  shape="circle"
-                  className="text-xl text-inherit"
-                  icon={<IconClose />}
-                  onClick={() => this.props.toggle(false)}
-                  aria-label="Fechar painel de métricas"
-                />
-              </div>
+        <div className="px-5 pb-5 flex-1">
+          <div className="flex w-full justify-between items-center pt-2 mt-1">
+            <div className="flex items-center">
+              <h2 className="my-0">Métricas</h2>
             </div>
 
-            {this.props.location && (
-              <>
-                <div className="mt-3 text-3xl leading-snug font-heading-display uppercase">
-                  {this.props.location.split(',')[0]}
-                </div>
-                <div className="mb-2 mt-2 text-lg tracking-tight opacity-50 leading-tight">
-                  {this.props.location.split(',')[1] && `${this.props.location.split(',')[1]}`}
-                </div>
-              </>
-            )}
-
-            {this.props.cityMetadata && this.props.cityMetadata.pnb_total !== undefined && (
-              <Section
-                title="PNB"
-                link={'https://itdpbrasil.org/pnb/'}
-                year={this.props.cityMetadata.pnb_year}
-                description={
-                  <>
-                    <p>
-                      O People Near Bike (pessoas próximas a bicicleta) é apurado anualmente pelo
-                      ITDP Brasil para avaliar as políticas de ciclomobilidade com maior efetividade
-                      e indica o percentual de pessoas que moram a até 300 metros de ciclovias e
-                      ciclofaixas.
-                    </p>
-                  </>
-                }
-              >
-                <BigNum>{this.props.cityMetadata.pnb_total + '%'}</BigNum>
-
-                {this.props.cityMetadata.pnb_black_women !== undefined && (
-                  <DataLine
-                    name="Mulheres negras"
-                    length={this.props.cityMetadata.pnb_black_women}
-                    unit="%"
+            <div className="flex items-center -mr-2">
+              {this.props.downloadData && (
+                <Dropdown
+                  trigger={['click']}
+                  placement="bottomRight"
+                  menu={{
+                    items: [
+                      {
+                        key: 'download',
+                        icon: <IconDownload className="mt-0.5 self-start" />,
+                        label: (
+                          <div className="max-w-[220px] py-0.5 leading-snug">
+                            <div>Baixar GeoJSON</div>
+                            <div className="mt-0.5 text-xs font-normal opacity-60 whitespace-normal">
+                              Dados da infraestrutura cicloviária desta cidade para uso em seus
+                              próprios projetos e análises.
+                            </div>
+                          </div>
+                        ),
+                      },
+                    ],
+                    onClick: ({ key }) => {
+                      if (key === 'download') this.props.downloadData();
+                    },
+                  }}
+                >
+                  <Button
+                    type="text"
+                    shape="circle"
+                    className="text-xl text-inherit"
+                    icon={<IconMore />}
+                    aria-label="Mais opções"
                   />
-                )}
-                {this.props.cityMetadata.pnb_women_less_one_salary !== undefined && (
-                  <DataLine
-                    name="Mulheres renda até 1 SM"
-                    length={this.props.cityMetadata.pnb_women_less_one_salary}
-                    unit="%"
-                  />
-                )}
-                {/* {
+                </Dropdown>
+              )}
+              <Button
+                type="text"
+                shape="circle"
+                className="text-xl text-inherit"
+                icon={<IconClose />}
+                onClick={() => this.props.toggle(false)}
+                aria-label="Fechar painel de métricas"
+              />
+            </div>
+          </div>
+
+          {this.props.location && (
+            <button
+              type="button"
+              className="mt-3 mb-2 text-left bg-transparent border-0 p-0 cursor-pointer text-inherit hover:opacity-80 transition-opacity duration-200"
+              onClick={this.props.openCityPicker}
+              aria-label={`Trocar cidade. Cidade atual: ${this.props.location}`}
+            >
+              <div className="text-3xl leading-snug uppercase font-heading-display">
+                {this.props.location.split(',')[0]}
+                <IconCaret
+                  className="inline-block opacity-60 ml-[0.15em] align-[-0.08em]"
+                  size="0.55em"
+                  aria-hidden
+                />
+              </div>
+              <div className="mt-2 text-lg tracking-tight opacity-50 leading-tight">
+                {this.props.location.split(',')[1] && `${this.props.location.split(',')[1]}`}
+              </div>
+            </button>
+          )}
+
+          {this.props.cityMetadata && this.props.cityMetadata.pnb_total !== undefined && (
+            <Section
+              title="PNB"
+              link={'https://itdpbrasil.org/pnb/'}
+              year={this.props.cityMetadata.pnb_year}
+              description={
+                <>
+                  <p>
+                    O People Near Bike (pessoas próximas a bicicleta) é apurado anualmente pelo ITDP
+                    Brasil para avaliar as políticas de ciclomobilidade com maior efetividade e
+                    indica o percentual de pessoas que moram a até 300 metros de ciclovias e
+                    ciclofaixas.
+                  </p>
+                </>
+              }
+            >
+              <BigNum>{this.props.cityMetadata.pnb_total + '%'}</BigNum>
+
+              {this.props.cityMetadata.pnb_black_women !== undefined && (
+                <DataLine
+                  name="Mulheres negras"
+                  length={this.props.cityMetadata.pnb_black_women}
+                  unit="%"
+                />
+              )}
+              {this.props.cityMetadata.pnb_women_less_one_salary !== undefined && (
+                <DataLine
+                  name="Mulheres renda até 1 SM"
+                  length={this.props.cityMetadata.pnb_women_less_one_salary}
+                  unit="%"
+                />
+              )}
+              {/* {
                                 this.props.cityMetadata.pnb_2024!==undefined &&
                                 <DataLine
                                     name="2024"
@@ -386,266 +410,261 @@ class AnalyticsSidebar extends Component {
                                 />
                             } */}
 
-                {pnbEvolutionData.length >= 2 && (
-                  <div>
-                    <div className="w-full mt-3" style={{ height: 124, marginBottom: -24 }}>
-                      <ResponsiveContainer width="100%" height="100%">
-                        <LineChart
-                          data={pnbEvolutionData}
-                          margin={{
-                            right: 12,
-                            left: 12,
-                            top: 1,
-                          }}
-                        >
-                          <XAxis
-                            dataKey="year"
-                            tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
-                            ticks={['2018', '2020', '2022', '2024']}
-                            interval={'preserveStartEnd'}
-                            margin={{ left: 8, right: 8 }}
-                            axisLine={false}
-                            tickLine={false}
-                          />
-                          <YAxis
-                            // domain={['dataMin', 'dataMax']}
-                            domain={[0, 50]}
-                            ticks={[15, 30, 50]}
-                            interval={'preserveEnd'}
-                            tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
-                            axisLine={false}
-                            tickLine={false}
-                            mirror={true}
-                          />
-                          <CartesianGrid
-                            stroke="currentColor"
-                            strokeOpacity={0.2}
-                            strokeWidth={0.5}
-                          />
-                          <RechartsTooltip {...pnbLineChartTooltipProps} />
-                          <Line
-                            type="monotone"
-                            dataKey="value"
-                            stroke={isDarkMode ? '#a8c957' : '#386641'}
-                            strokeWidth={2}
-                            dot={{ r: 1 }}
-                          />
-                        </LineChart>
-                      </ResponsiveContainer>
-                    </div>
+              {pnbEvolutionData.length >= 2 && (
+                <div>
+                  <div className="w-full mt-3" style={{ height: 124, marginBottom: -24 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart
+                        data={pnbEvolutionData}
+                        margin={{
+                          right: 12,
+                          left: 12,
+                          top: 1,
+                        }}
+                      >
+                        <XAxis
+                          dataKey="year"
+                          tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
+                          ticks={['2018', '2020', '2022', '2024']}
+                          interval={'preserveStartEnd'}
+                          margin={{ left: 8, right: 8 }}
+                          axisLine={false}
+                          tickLine={false}
+                        />
+                        <YAxis
+                          // domain={['dataMin', 'dataMax']}
+                          domain={[0, 50]}
+                          ticks={[15, 30, 50]}
+                          interval={'preserveEnd'}
+                          tick={{ fill: 'currentColor', opacity: 0.5, fontSize: 10 }}
+                          axisLine={false}
+                          tickLine={false}
+                          mirror={true}
+                        />
+                        <CartesianGrid
+                          stroke="currentColor"
+                          strokeOpacity={0.2}
+                          strokeWidth={0.5}
+                        />
+                        <RechartsTooltip {...pnbLineChartTooltipProps} />
+                        <Line
+                          type="monotone"
+                          dataKey="value"
+                          stroke={isDarkMode ? '#a8c957' : '#386641'}
+                          strokeWidth={2}
+                          dot={{ r: 1 }}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
                   </div>
-                )}
-              </Section>
-            )}
+                </div>
+              )}
+            </Section>
+          )}
 
-            {this.props.cityMetadata && this.props.cityMetadata.ideciclo !== undefined && (
-              <Section
-                title="IDECiclo"
-                link="https://www.ideciclo.org/"
-                year={this.props.cityMetadata.ideciclo_year}
-                description={
-                  <>
-                    <p>
-                      O Índice de Desenvolvimento Cicloviário (IDECICLO) tem como objetivo avaliar
-                      qualitativamente a infraestrutura cicloviária da cidade de forma objetiva e
-                      replicável de modo que haja acompanhamento da evolução dos parâmetros para uma
-                      comparação entre infraestruturas e entre cidades, de maneira a construir uma
-                      séria histórica.
-                    </p>
-                    <p>
-                      O IDECICLO faz uma avaliação local de cada estrutura e pondera esta sob a
-                      malha total da cidade e com as velocidades máximas das vias que estão sendo
-                      inseridas, podendo ser um índice comparativo entre cidades e entre estruturas.
-                    </p>
-                    <p>Escala: de 0 a 1.</p>
-                  </>
-                }
-              >
-                <BigNum>{this.props.cityMetadata.ideciclo}</BigNum>
-              </Section>
-            )}
-
+          {this.props.cityMetadata && this.props.cityMetadata.ideciclo !== undefined && (
             <Section
-              title="Vias"
+              title="IDECiclo"
+              link="https://www.ideciclo.org/"
+              year={this.props.cityMetadata.ideciclo_year}
               description={
                 <>
                   <p>
-                    As extensões totais das vias são calculadas automaticamente com base nos dados
-                    do OpenStreetMap.
+                    O Índice de Desenvolvimento Cicloviário (IDECICLO) tem como objetivo avaliar
+                    qualitativamente a infraestrutura cicloviária da cidade de forma objetiva e
+                    replicável de modo que haja acompanhamento da evolução dos parâmetros para uma
+                    comparação entre infraestruturas e entre cidades, de maneira a construir uma
+                    séria histórica.
                   </p>
                   <p>
-                    Para vias que tem estrutura dos dois lados nós desenvolvemos um método que
-                    automaticamente detecta estes casos e remove esta contagem dupla do total.
+                    O IDECICLO faz uma avaliação local de cada estrutura e pondera esta sob a malha
+                    total da cidade e com as velocidades máximas das vias que estão sendo inseridas,
+                    podendo ser um índice comparativo entre cidades e entre estruturas.
                   </p>
-                  <OpenStreetMapDisclaimer />
+                  <p>Escala: de 0 a 1.</p>
                 </>
               }
             >
-              {this.props.debugMode && strategiesDropdown}
+              <BigNum>{this.props.cityMetadata.ideciclo}</BigNum>
+            </Section>
+          )}
 
-              <div className="relative">
-                <PieChart width={PIE_CHART_WIDTH_PX} height={PIE_CHART_WIDTH_PX}>
-                  <defs>{this.generatePatterns(layers)}</defs>
-                  <Pie
-                    data={vias.pieSlices}
-                    dataKey="value"
-                    cx={'50%'}
-                    cy={'50%'}
-                    innerRadius={90}
-                    outerRadius={100}
-                    paddingAngle={vias.hasPieBreakdown ? 4 : 0}
-                    strokeWidth={0}
-                    startAngle={90}
-                    endAngle={450}
-                    cornerRadius="50%"
-                  />
-                </PieChart>
+          <Section
+            title="Vias"
+            description={
+              <>
+                <p>
+                  As extensões totais das vias são calculadas automaticamente com base nos dados do
+                  OpenStreetMap.
+                </p>
+                <p>
+                  Para vias que tem estrutura dos dois lados nós desenvolvemos um método que
+                  automaticamente detecta estes casos e remove esta contagem dupla do total.
+                </p>
+                <OpenStreetMapDisclaimer />
+              </>
+            }
+          >
+            {this.props.debugMode && strategiesDropdown}
 
-                <div
-                  className="absolute top-0 w-full flex flex-col items-center justify-center"
-                  style={{ height: `${PIE_CHART_WIDTH_PX}px`, width: `${PIE_CHART_WIDTH_PX}px` }}
-                >
-                  {lengths && vias.rawTotal > 0 ? (
-                    <>
-                      <span className="inline-flex flex-col items-center cursor-default">
-                        <span className="tracking-wides text-xs">TOTAL</span>
-                        <span className="font-regular">
-                          <span className="text-4xl tracking-tighter">
-                            {vias.effectiveTotal.toFixed(1)}
-                          </span>
-                          <span className="text-sm">{`${THIN_SPACE}km`}</span>
+            <div className="relative">
+              <PieChart width={PIE_CHART_WIDTH_PX} height={PIE_CHART_WIDTH_PX}>
+                <defs>{this.generatePatterns(layers)}</defs>
+                <Pie
+                  data={vias.pieSlices}
+                  dataKey="value"
+                  cx={'50%'}
+                  cy={'50%'}
+                  innerRadius={90}
+                  outerRadius={100}
+                  paddingAngle={vias.hasPieBreakdown ? 4 : 0}
+                  strokeWidth={0}
+                  startAngle={90}
+                  endAngle={450}
+                  cornerRadius="50%"
+                />
+              </PieChart>
+
+              <div
+                className="absolute top-0 w-full flex flex-col items-center justify-center"
+                style={{ height: `${PIE_CHART_WIDTH_PX}px`, width: `${PIE_CHART_WIDTH_PX}px` }}
+              >
+                {lengths && vias.rawTotal > 0 ? (
+                  <>
+                    <span className="inline-flex flex-col items-center cursor-default">
+                      <span className="tracking-wides text-xs">TOTAL</span>
+                      <span className="font-regular">
+                        <span className="text-4xl tracking-tighter">
+                          {vias.effectiveTotal.toFixed(1)}
                         </span>
+                        <span className="text-sm">{`${THIN_SPACE}km`}</span>
                       </span>
-                      {ENABLE_OFFICIAL_CITY_HALL_METRICS_COMPARISON &&
-                        this.props.cityMetadata &&
-                        this.props.cityMetadata.alianca_2025 !== undefined &&
-                        this.props.cityMetadata.alianca_2025 !== null && (
-                          <>
-                            {/* <span className="tracking-widest mt-2">OFICIAL</span> */}
-                            <Popover
-                              placement="left"
-                              arrow={{ pointAtCenter: true }}
-                              content={
-                                <div
-                                  className="flex flex-col gap-3 leading-normal"
-                                  style={{ width: 320 }}
+                    </span>
+                    {ENABLE_OFFICIAL_CITY_HALL_METRICS_COMPARISON &&
+                      this.props.cityMetadata &&
+                      this.props.cityMetadata.alianca_2025 !== undefined &&
+                      this.props.cityMetadata.alianca_2025 !== null && (
+                        <>
+                          {/* <span className="tracking-widest mt-2">OFICIAL</span> */}
+                          <Popover
+                            placement="left"
+                            arrow={{ pointAtCenter: true }}
+                            content={
+                              <div
+                                className="flex flex-col gap-3 leading-normal"
+                                style={{ width: 320 }}
+                              >
+                                <h3 className="text-lg flex items-center gap-1">
+                                  <IconVerified className="inline-block text-green-300 text-xl" />{' '}
+                                  Dado Oficial da Prefeitura
+                                </h3>
+                                <p>
+                                  Quilometragem total de ciclovias e ciclofaixas divulgada como dado
+                                  oficial da Prefeitura com base no levantamento anual da Aliança
+                                  Bike. Última atualização: julho de 2025.
+                                </p>
+                                <OfficialDisclaimer />
+                                <Button
+                                  type="primary"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  href="https://aliancabike.org.br/dados-do-setor/ciclovias-e-ciclofaixas/"
                                 >
-                                  <h3 className="text-lg flex items-center gap-1">
-                                    <IconVerified className="inline-block text-green-300 text-xl" />{' '}
-                                    Dado Oficial da Prefeitura
-                                  </h3>
-                                  <p>
-                                    Quilometragem total de ciclovias e ciclofaixas divulgada como
-                                    dado oficial da Prefeitura com base no levantamento anual da
-                                    Aliança Bike. Última atualização: julho de 2025.
-                                  </p>
-                                  <OfficialDisclaimer />
-                                  <Button
-                                    type="primary"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    href="https://aliancabike.org.br/dados-do-setor/ciclovias-e-ciclofaixas/"
-                                  >
-                                    Saiba mais
-                                  </Button>
-                                </div>
-                              }
-                            >
-                              <span className="flex items-center decoration-dotted tracking-tight gap-0.5">
-                                <IconVerified className="inline-block opacity-50" />
-                                <div className="flex items-center items-baseline opacity-70">
-                                  {appendKmUnit(
-                                    Number(this.props.cityMetadata.alianca_2025).toFixed(1)
-                                  )}
-                                </div>
-                                {/* <IconInfo /> */}
-                              </span>
-                            </Popover>
-                          </>
-                        )}
-                    </>
-                  ) : (
-                    <span className="opacity-50">Sem dados</span>
-                  )}
+                                  Saiba mais
+                                </Button>
+                              </div>
+                            }
+                          >
+                            <span className="flex items-center decoration-dotted tracking-tight gap-0.5">
+                              <IconVerified className="inline-block opacity-50" />
+                              <div className="flex items-center items-baseline opacity-70">
+                                {appendKmUnit(
+                                  Number(this.props.cityMetadata.alianca_2025).toFixed(1)
+                                )}
+                              </div>
+                              {/* <IconInfo /> */}
+                            </span>
+                          </Popover>
+                        </>
+                      )}
+                  </>
+                ) : (
+                  <span className="opacity-50">Sem dados</span>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-2">
+              {vias.infraLayers.map((l) => (
+                <ViaDataRow
+                  key={l.id}
+                  layer={l}
+                  length={lengths && lengths[l.id]}
+                  rawTotal={vias.rawTotal}
+                  effectiveTotal={vias.effectiveTotal}
+                  included={this.state.lengthsInclude[l.id]}
+                  onToggleInclude={() => this.toggleLengthsInclude(l.id)}
+                />
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Pontos de interesse">
+            {layers
+              .filter((l) => l.type === 'poi' && l.name !== 'Comentários')
+              .map(
+                (l) =>
+                  lengths &&
+                  lengths[l.id] >= 0 && (
+                    <DataLine name={l.name} key={l.name} length={lengths[l.id]} />
+                  )
+              )}
+          </Section>
+        </div>
+
+        {(this.props.loading || this.props.lastUpdate) && (
+          <div className="mt-auto bg-white bg-opacity-5">
+            {this.props.loading && (
+              <div className="loader-container h-1">
+                <div className="progress-materializecss">
+                  <div className="indeterminate"></div>
                 </div>
               </div>
-
-              <div className="mt-2">
-                {vias.infraLayers.map((l) => (
-                  <ViaDataRow
-                    key={l.id}
-                    layer={l}
-                    length={lengths && lengths[l.id]}
-                    rawTotal={vias.rawTotal}
-                    effectiveTotal={vias.effectiveTotal}
-                    included={this.state.lengthsInclude[l.id]}
-                    onToggleInclude={() => this.toggleLengthsInclude(l.id)}
-                  />
-                ))}
-              </div>
-            </Section>
-
-            <Section title="Pontos de interesse">
-              {layers
-                .filter((l) => l.type === 'poi' && l.name !== 'Comentários')
-                .map(
-                  (l) =>
-                    lengths &&
-                    lengths[l.id] >= 0 && (
-                      <DataLine name={l.name} key={l.name} length={lengths[l.id]} />
-                    )
-                )}
-            </Section>
-          </div>
-
-          {(this.props.loading || this.props.lastUpdate) && (
-            <div className="mt-auto pt-7">
+            )}
+            <div className="px-5 py-3 flex flex-col gap-2.5">
               {this.props.loading ? (
-                <div className="flex items-center gap-1 text-xs opacity-50 hover:opacity-100 transition-opacity duration-300">
-                  Carregando dados do OpenStreetMap...
+                <>
+                  <p className="m-0 text-xs leading-snug opacity-70">
+                    Carregando dados do OpenStreetMap...
+                  </p>
                   <Button
                     type="link"
                     size="small"
-                    className="text-xs p-0 h-auto min-h-0 text-inherit opacity-70 hover:opacity-100"
+                    className="self-start p-0 h-auto text-xs"
                     onClick={this.props.cancelDataLoad}
                   >
                     Cancelar
                   </Button>
-                </div>
+                </>
               ) : (
-                <Popover
-                  placement="top"
-                  arrow={{ pointAtCenter: true }}
-                  content={
-                    <div style={{ maxWidth: 250 }}>
-                      <Space size="small" orientation="vertical">
-                        <div>
-                          Estes dados são uma cópia do OpenStreetMap obtida há{' '}
-                          <b>{timeSince(this.props.lastUpdate)}</b> (
-                          {this.props.lastUpdate.toLocaleString('pt-BR')}).
-                        </div>
-
-                        <Button
-                          size="small"
-                          icon={<IconUpdate />}
-                          type="primary"
-                          block
-                          onClick={this.props.forceUpdate}
-                        >
-                          Atualizar
-                        </Button>
-                      </Space>
-                    </div>
-                  }
-                >
-                  <div className="inline-flex items-center gap-1 text-xs opacity-50 hover:opacity-100 cursor transition-opacity duration-300">
-                    Atualizado há {timeSince(this.props.lastUpdate)}
-                  </div>
-                </Popover>
+                <>
+                  <p className="m-0 text-xs leading-snug opacity-70">
+                    Dados obtidos do OpenStreetMap há {timeSince(this.props.lastUpdate)}.
+                  </p>
+                  <Button
+                    type="link"
+                    size="small"
+                    icon={<IconUpdate />}
+                    className="self-start p-0 h-auto text-xs"
+                    onClick={() => this.confirmForceUpdate()}
+                  >
+                    Atualizar
+                  </Button>
+                </>
               )}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     );
   }
@@ -667,6 +686,7 @@ AnalyticsSidebar.propTypes = {
   loading: PropTypes.bool,
   forceUpdate: PropTypes.func,
   cancelDataLoad: PropTypes.func,
+  openCityPicker: PropTypes.func,
 };
 
 const BigNum = ({ children }) => (

--- a/src/App.js
+++ b/src/App.js
@@ -1749,6 +1749,12 @@ class App extends Component {
     this.loadAirtableMetadata();
     this.syncPrivacyPolicyFromRoute();
 
+    // Sidebar/routes open state can be restored from localStorage before any toggle
+    // fires — kick off deferred GeoJSON (boundary, metrics, freshness) in that case.
+    if (this.needsCityGeoJsonContext()) {
+      this.ensureCityDataLoaded();
+    }
+
     // Safety net for the GTM `mapReady` trigger: the map normally signals readiness
     // on its first idle, but if the map never mounts or fails (WebGL error, very slow
     // device), we still let deferred analytics (PostHog) load so we don't lose tracking.

--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ import {
   ABOUT_MODAL_ALWAYS_AUTO_OPEN_IN_NON_PROD,
   THRESHOLD_NEW_VS_OLD_DATA_TOLERANCE,
   IS_MOBILE,
+  PMTILES_EXCLUDED_LAYER_NAMES,
   FORCE_RECALCULATE_LENGTHS_ALWAYS,
   DEFAULT_LENGTH_CALCULATE_STRATEGIES,
   MAP_STYLES,
@@ -445,6 +446,14 @@ class App extends Component {
       layers.forEach((l) => {
         if (prevLayersStates[l.id] !== undefined) {
           l.isActive = prevLayersStates[l.id];
+        }
+      });
+    }
+
+    if (IS_MOBILE) {
+      layers.forEach((l) => {
+        if (PMTILES_EXCLUDED_LAYER_NAMES.has(l.name)) {
+          l.isActive = false;
         }
       });
     }

--- a/src/App.js
+++ b/src/App.js
@@ -84,7 +84,6 @@ class App extends Component {
   lastResolvedCitySlug = null;
   lastNotifiedCitySlugError = null;
   initialBareRootEntry = false;
-  _lastExplicitCityNavTimestamp = 0;
   _welcomeMapBootScheduled = false;
   _unmounted = false;
   /** Mobile directions panel open state (kept off React state to avoid App-wide re-renders). */
@@ -722,7 +721,6 @@ class App extends Component {
     if (this.lastResolvedCitySlug === citySlug) return;
 
     this.lastResolvedCitySlug = citySlug;
-    this._lastExplicitCityNavTimestamp = Date.now();
 
     try {
       const normalizedSlug = decodeURIComponent(citySlug).trim().toLowerCase();
@@ -1192,9 +1190,7 @@ class App extends Component {
       this.abortCurrentOSMRequest();
     }
 
-    if (!backgroundUpdate) {
-      this.setState({ loading: true });
-    }
+    this.setState({ loading: true });
 
     // const parts = areaName.split(',');
     // const city = parts[0];
@@ -1268,7 +1264,7 @@ class App extends Component {
           this.setState({
             geoJson: newData.geoJson,
             dataUpdatedAt: new Date(),
-            ...(backgroundUpdate ? {} : { loading: false }),
+            loading: false,
             lengths: lengths,
           });
 
@@ -1517,12 +1513,6 @@ class App extends Component {
     const currCitySlug = this.getCitySlugFromRoute();
     if (prevCitySlug !== currCitySlug) {
       this.lastResolvedCitySlug = null;
-      // Stamp the navigation timestamp immediately so that any in-flight stale geocodes
-      // from the previous city are suppressed regardless of which branch below runs.
-      // Without this, resolveCitySlugToAreaAndViewport might be skipped (e.g. when
-      // hasExplicitViewportInURL is true) and the timestamp would never be updated,
-      // letting stale geocodes overwrite the new city slug.
-      this._lastExplicitCityNavTimestamp = Date.now();
       if (currCitySlug) {
         const routeWasNormalized = this.normalizeCitySlugRouteIfNeeded();
         if (routeWasNormalized) return;
@@ -1829,35 +1819,14 @@ class App extends Component {
   }
 
   onMapMoved(newState) {
-    // Area/city change path (rare): this DOES go through setState because `area`
-    // is rendered and drives data loading.
-    // This does NOT control the map - the map manages its own position
+    // This does NOT control the map - the map manages its own position.
+    // City/area is no longer inferred from pan/zoom; it only changes via the
+    // city picker, URL slug, or an explicit setArea (e.g. routing).
     requestAnimationFrame(() => {
       const nextState = { ...newState };
       if (typeof nextState.area === 'string' && nextState.area.trim()) {
-        const normalized = this.normalizeAreaLabelForDisplay(nextState.area);
-
-        // Guard against stale reverse-geocode results: a geocode that was *requested before*
-        // an explicit city navigation (picker, direct URL) can resolve afterwards and overwrite
-        // the new slug.  We detect this by comparing the geocode's request timestamp
-        // (_geocodeRequestTime, set in Map.onMapMoveEnded) against the last navigation
-        // timestamp.  Geocodes requested after the navigation are always accepted.
-        const routeSlug = this.getCanonicalRouteCitySlug();
-        if (normalized && routeSlug) {
-          const candidateSlug = this.getCitySlugFromArea(normalized);
-          const geocodeRequestTime = nextState._geocodeRequestTime ?? Date.now();
-          const isStaleGeocode = geocodeRequestTime < this._lastExplicitCityNavTimestamp;
-          if (candidateSlug && candidateSlug !== routeSlug && isStaleGeocode) {
-            // Stale geocode result — drop the area update to protect the current slug.
-            delete nextState.area;
-          } else {
-            nextState.area = normalized;
-          }
-        } else {
-          nextState.area = normalized;
-        }
+        nextState.area = this.normalizeAreaLabelForDisplay(nextState.area);
       }
-      delete nextState._geocodeRequestTime;
       this.setState(nextState);
     });
   }
@@ -1884,13 +1853,13 @@ class App extends Component {
       this.ensureCityDataLoaded();
     }
     // Directions open state is kept off React state (avoids App-wide re-renders), so
-    // poke Map directly — same gate as Analytics for boundary + live area tracking.
+    // poke Map directly — same gate as Analytics for boundary visibility.
     this.mapComponent?.initBoundaryLayer?.();
   }
 
-  // Shared gate for anything that needs per-city GeoJSON / a live area label:
-  // Analytics sidebar, Routing panel, city boundary, and Mapbox reverse-geocode on pan.
-  // Idle map browsing stays on PMTiles only.
+  // Shared gate for anything that needs per-city GeoJSON: Analytics sidebar,
+  // Routing panel, and the city boundary outline. Idle map browsing stays on
+  // PMTiles only; city/area itself is only changed via the picker / URL.
   needsCityGeoJsonContext() {
     return this.state.isSidebarOpen || this._isDirectionsPanelOpen;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1577,10 +1577,6 @@ class App extends Component {
         });
       }
 
-      if (!IS_MOBILE) {
-        document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
-      }
-
       // Only redo the query if we need new data
       // if (!doesAContainsB(largestBoundsYet, newBounds)) {
       //     this.updateData();

--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,10 @@ class App extends Component {
   _storage = null;
   osmController = OSMController;
   currentOSMRequest = null;
+  // Tracks which area's GeoJSON is currently loaded/in-flight, so ensureCityDataLoaded()
+  // can avoid redundant Firestore/Overpass hits when data is deferred (see updateData()).
+  _geoJsonLoadedArea = null;
+  _geoJsonLoadingArea = null;
   deferredCityFocus = null;
   // Fly-to target from the `?flyto=lat,lng[,zoom]` URL param; consumed when the map mounts.
   pendingFlyToTarget = null;
@@ -95,6 +99,7 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.updateData = this.updateData.bind(this);
+    this.ensureCityDataLoaded = this.ensureCityDataLoaded.bind(this);
     this.onMapStyleChange = this.onMapStyleChange.bind(this);
     this.onMapShowSatelliteChanged = this.onMapShowSatelliteChanged.bind(this);
     this.onMapMoved = this.onMapMoved.bind(this);
@@ -352,6 +357,9 @@ class App extends Component {
 
   toggleSidebar(state) {
     this.setState({ isSidebarOpen: state });
+    if (state) {
+      this.ensureCityDataLoaded();
+    }
   }
 
   openAboutModal() {
@@ -1252,6 +1260,11 @@ class App extends Component {
             lengths: lengths,
           });
 
+          this._geoJsonLoadedArea = areaName;
+          if (this._geoJsonLoadingArea === areaName) {
+            this._geoJsonLoadingArea = null;
+          }
+
           appNotification.destroy();
 
           // notification.success({
@@ -1269,6 +1282,10 @@ class App extends Component {
         this.setState({
           loading: false,
         });
+
+        if (this._geoJsonLoadingArea === areaName) {
+          this._geoJsonLoadingArea = null;
+        }
 
         appNotification.destroy();
 
@@ -1313,7 +1330,7 @@ class App extends Component {
         const storageKey = this.getStorageKeyForArea(area);
         const cacheLoadToken = startDataLoad('geojson-cache', 'GeoJSON (cache)', { area });
         this.getStorage()
-          .load(this.state.area, { storageKey })
+          .load(area, { storageKey })
           .then((data) => {
             if (data) {
               finishDataLoad('geojson-cache', {
@@ -1348,10 +1365,13 @@ class App extends Component {
                 lengths: data.lengths,
                 dataUpdatedAt: new Date(data.updatedAt),
               });
+
+              this._geoJsonLoadedArea = area;
+              if (this._geoJsonLoadingArea === area) {
+                this._geoJsonLoadingArea = null;
+              }
             } else {
-              console.debug(
-                `Couldn't find previously saved data for area ${this.state.area}, hitting OSM...`
-              );
+              console.debug(`Couldn't find previously saved data for area ${area}, hitting OSM...`);
 
               finishDataLoad('geojson-cache', {
                 token: cacheLoadToken,
@@ -1369,7 +1389,11 @@ class App extends Component {
           })
           .catch((e) => {
             console.error(e);
-            finishDataLoad('geojson-cache', { token: cacheLoadToken, error: e, meta: { area } });
+            finishDataLoad('geojson-cache', { error: e, meta: { area } });
+
+            if (this._geoJsonLoadingArea === area) {
+              this._geoJsonLoadingArea = null;
+            }
             // notification['error']({
             //     message: 'Erro',
             //     description:
@@ -1380,6 +1404,19 @@ class App extends Component {
     } else {
       this.setState({ loading: false });
     }
+  }
+
+  // Map rendering runs entirely off the regional PMTiles, so per-city GeoJSON is only
+  // needed by routing coverage, analytics/km stats, and the GeoJSON export. Call this
+  // right before any of those features are used instead of loading eagerly on every
+  // city change.
+  ensureCityDataLoaded() {
+    const area = this.state.area;
+    if (!area || this._geoJsonLoadedArea === area || this._geoJsonLoadingArea === area) {
+      return;
+    }
+    this._geoJsonLoadingArea = area;
+    this.updateData();
   }
 
   onMapStyleChange(newMapStyle) {
@@ -1425,6 +1462,17 @@ class App extends Component {
   }
 
   downloadData() {
+    if (!this.state.geoJson) {
+      // Data is loaded on-demand (see ensureCityDataLoaded); if the user clicks
+      // download before it's ready, kick off the load and ask them to retry shortly.
+      this.ensureCityDataLoaded();
+      appNotification.info({
+        title: 'Só um momento',
+        description: 'Ainda estamos carregando os dados desta cidade. Tente novamente em breve.',
+      });
+      return;
+    }
+
     Analytics.event('purchase', {
       items: [
         {
@@ -1496,7 +1544,18 @@ class App extends Component {
 
       this.recordRecentlyVisitedCity(this.state.area);
 
-      this.updateData();
+      // Map rendering is driven entirely by PMTiles, so per-city GeoJSON is no longer
+      // fetched eagerly on every city change (see ensureCityDataLoaded). Just clear out
+      // the previous city's data/in-flight tracking; Analytics/Routing/Export will
+      // (re)request it on demand. If one of those panels is already open, though, it
+      // needs data for the *new* city right away.
+      this.abortCurrentOSMRequest();
+      this._geoJsonLoadedArea = null;
+      this._geoJsonLoadingArea = null;
+      this.setState({ geoJson: null, lengths: {}, dataUpdatedAt: null });
+      if (this.state.isSidebarOpen || this.state.isDirectionsPanelOpen) {
+        this.ensureCityDataLoaded();
+      }
 
       if (Array.isArray(this.state.airtableMetadataRecords)) {
         this.syncAirtableCityFields();
@@ -1510,7 +1569,9 @@ class App extends Component {
         });
       }
 
-      document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
+      if (!IS_MOBILE) {
+        document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
+      }
 
       // Only redo the query if we need new data
       // if (!doesAContainsB(largestBoundsYet, newBounds)) {
@@ -1799,6 +1860,9 @@ class App extends Component {
 
   onDirectionsPanelToggle(isOpen) {
     this._isDirectionsPanelOpen = isOpen;
+    if (isOpen) {
+      this.ensureCityDataLoaded();
+    }
   }
 
   setFromPoint = (point) => {

--- a/src/App.js
+++ b/src/App.js
@@ -105,6 +105,7 @@ class App extends Component {
     this.onMapShowSatelliteChanged = this.onMapShowSatelliteChanged.bind(this);
     this.onMapMoved = this.onMapMoved.bind(this);
     this.onMapPositionChange = this.onMapPositionChange.bind(this);
+    this.needsCityGeoJsonContext = this.needsCityGeoJsonContext.bind(this);
     this.getMapViewport = this.getMapViewport.bind(this);
     this.onLayersChange = this.onLayersChange.bind(this);
     this.downloadData = this.downloadData.bind(this);
@@ -356,10 +357,13 @@ class App extends Component {
   }
 
   toggleSidebar(state) {
-    this.setState({ isSidebarOpen: state });
-    if (state) {
-      this.ensureCityDataLoaded();
-    }
+    this.setState({ isSidebarOpen: state }, () => {
+      if (state) {
+        this.ensureCityDataLoaded();
+      }
+      // Boundary visibility follows the same Analytics/Routing gate as GeoJSON loading.
+      this.mapComponent?.initBoundaryLayer?.();
+    });
   }
 
   openAboutModal() {
@@ -1415,9 +1419,9 @@ class App extends Component {
   }
 
   // Map rendering runs entirely off the regional PMTiles, so per-city GeoJSON is only
-  // needed by routing coverage, analytics/km stats, and the GeoJSON export. Call this
-  // right before any of those features are used instead of loading eagerly on every
-  // city change.
+  // needed by routing coverage, analytics/km stats, the city boundary outline, and the
+  // GeoJSON export. Call this right before any of those features are used instead of
+  // loading eagerly on every city change.
   ensureCityDataLoaded() {
     const area = this.state.area;
     if (!area || this._geoJsonLoadedArea === area || this._geoJsonLoadingArea === area) {
@@ -1561,7 +1565,7 @@ class App extends Component {
       this._geoJsonLoadedArea = null;
       this._geoJsonLoadingArea = null;
       this.setState({ geoJson: null, lengths: {}, dataUpdatedAt: null });
-      if (this.state.isSidebarOpen || this._isDirectionsPanelOpen) {
+      if (this.needsCityGeoJsonContext()) {
         this.ensureCityDataLoaded();
       }
 
@@ -1873,6 +1877,16 @@ class App extends Component {
     if (isOpen) {
       this.ensureCityDataLoaded();
     }
+    // Directions open state is kept off React state (avoids App-wide re-renders), so
+    // poke Map directly — same gate as Analytics for boundary + live area tracking.
+    this.mapComponent?.initBoundaryLayer?.();
+  }
+
+  // Shared gate for anything that needs per-city GeoJSON / a live area label:
+  // Analytics sidebar, Routing panel, city boundary, and Mapbox reverse-geocode on pan.
+  // Idle map browsing stays on PMTiles only.
+  needsCityGeoJsonContext() {
+    return this.state.isSidebarOpen || this._isDirectionsPanelOpen;
   }
 
   toggleDirectionsPanel() {
@@ -1977,6 +1991,7 @@ class App extends Component {
       downloadData: this.downloadData,
       onMapMoved: this.onMapMoved,
       onMapPositionChange: this.onMapPositionChange,
+      needsCityGeoJsonContext: this.needsCityGeoJsonContext,
       getMapViewport: this.getMapViewport,
       forceUpdate: this.forceUpdate,
       cancelDataLoad: this.cancelDataLoad,

--- a/src/App.js
+++ b/src/App.js
@@ -141,10 +141,6 @@ class App extends Component {
       !initialHasCitySlug;
 
     this.state = this.buildInitialState();
-
-    if (this.state.mapBootReady) {
-      this.updateData();
-    }
   }
 
   buildInitialState() {
@@ -1683,9 +1679,7 @@ class App extends Component {
 
   startDeferredMapBoot() {
     if (this.state.mapBootReady) return;
-    this.setState({ mapBootReady: true }, () => {
-      this.updateData();
-    });
+    this.setState({ mapBootReady: true });
   }
 
   componentDidMount() {

--- a/src/App.js
+++ b/src/App.js
@@ -1558,7 +1558,7 @@ class App extends Component {
       this._geoJsonLoadedArea = null;
       this._geoJsonLoadingArea = null;
       this.setState({ geoJson: null, lengths: {}, dataUpdatedAt: null });
-      if (this.state.isSidebarOpen || this.state.isDirectionsPanelOpen) {
+      if (this.state.isSidebarOpen || this._isDirectionsPanelOpen) {
         this.ensureCityDataLoaded();
       }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1394,7 +1394,7 @@ class App extends Component {
           })
           .catch((e) => {
             console.error(e);
-            finishDataLoad('geojson-cache', { error: e, meta: { area } });
+            finishDataLoad('geojson-cache', { token: cacheLoadToken, error: e, meta: { area } });
 
             if (this._geoJsonLoadingArea === area) {
               this._geoJsonLoadingArea = null;

--- a/src/App.js
+++ b/src/App.js
@@ -121,10 +121,13 @@ class App extends Component {
     this.syncPrivacyPolicyFromRoute = this.syncPrivacyPolicyFromRoute.bind(this);
     this.onChangeStrategy = this.onChangeStrategy.bind(this);
     this.setMapRef = this.setMapRef.bind(this);
+    this.setMapComponentRef = this.setMapComponentRef.bind(this);
+    this.triggerGeolocate = this.triggerGeolocate.bind(this);
     this.toggleTheme = this.toggleTheme.bind(this);
     this.forceMapReinitialization = this.forceMapReinitialization.bind(this);
     this.setDirectionsPanelRef = this.setDirectionsPanelRef.bind(this);
     this.onDirectionsPanelToggle = this.onDirectionsPanelToggle.bind(this);
+    this.toggleDirectionsPanel = this.toggleDirectionsPanel.bind(this);
     this.setArea = this.setArea.bind(this);
     this.debouncedUpdateURL = debounce(this.updateURL, 300);
 
@@ -1857,6 +1860,14 @@ class App extends Component {
     this.setState({ map });
   }
 
+  setMapComponentRef(mapComponent) {
+    this.mapComponent = mapComponent;
+  }
+
+  triggerGeolocate() {
+    this.mapComponent?.triggerGeolocate?.();
+  }
+
   setDirectionsPanelRef(directionsPanel) {
     this.directionsPanel = directionsPanel;
   }
@@ -1866,6 +1877,10 @@ class App extends Component {
     if (isOpen) {
       this.ensureCityDataLoaded();
     }
+  }
+
+  toggleDirectionsPanel() {
+    this.directionsPanel?.toggleCollapse?.();
   }
 
   setFromPoint = (point) => {
@@ -1974,6 +1989,8 @@ class App extends Component {
       toggleTheme: this.toggleTheme,
       updateLengths: this.updateLengths,
       setMapRef: this.setMapRef,
+      setMapComponentRef: this.setMapComponentRef,
+      triggerGeolocate: this.triggerGeolocate,
       onTrackingUserLocationChange: (isTracking) => {
         this.setState({ isTrackingUserLocation: isTracking });
         this.saveStateToLocalStorage();
@@ -1987,6 +2004,7 @@ class App extends Component {
       setToPoint: this.setToPoint,
       clearRoutePoints: this.clearRoutePoints,
       onDirectionsPanelToggle: this.onDirectionsPanelToggle,
+      toggleDirectionsPanel: this.toggleDirectionsPanel,
       setArea: this.setArea,
       openLayersLegendModal: this.openLayersLegendModal,
       closeAboutModal: this.closeAboutModal,

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -138,6 +138,7 @@ export default function AppLayout({
                   loading={state.loading}
                   forceUpdate={handlers.forceUpdate}
                   cancelDataLoad={handlers.cancelDataLoad}
+                  openCityPicker={handlers.openCityPicker}
                 />
               </Suspense>
             </aside>

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -55,14 +55,12 @@ export default function AppLayout({
           <header id="topbar-wrapper" aria-label="Barra superior">
             <TopBar
               title={state.area}
-              lastUpdate={state.dataUpdatedAt}
               lat={state.lat}
               lng={state.lng}
               z={state.zoom}
               getViewport={handlers.getMapViewport}
               downloadData={handlers.downloadData}
               onMapMoved={handlers.onMapMoved}
-              forceUpdate={handlers.forceUpdate}
               isSidebarOpen={state.isSidebarOpen}
               toggleSidebar={handlers.toggleSidebar}
               embedMode={state.embedMode}
@@ -70,8 +68,6 @@ export default function AppLayout({
               openAboutModal={handlers.openAboutModal}
               isDarkMode={state.isDarkMode}
               toggleTheme={handlers.toggleTheme}
-              loading={state.loading}
-              cancelDataLoad={handlers.cancelDataLoad}
               toggleDirectionsPanel={handlers.toggleDirectionsPanel}
               triggerGeolocate={handlers.triggerGeolocate}
             />
@@ -138,6 +134,10 @@ export default function AppLayout({
                   toggle={handlers.toggleSidebar}
                   onChangeStrategy={handlers.onChangeStrategy}
                   downloadData={handlers.downloadData}
+                  lastUpdate={state.dataUpdatedAt}
+                  loading={state.loading}
+                  forceUpdate={handlers.forceUpdate}
+                  cancelDataLoad={handlers.cancelDataLoad}
                 />
               </Suspense>
             </aside>

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -95,6 +95,7 @@ export default function AppLayout({
               location={state.area}
               onMapMoved={handlers.onMapMoved}
               onMapPositionChange={handlers.onMapPositionChange}
+              needsCityGeoJsonContext={handlers.needsCityGeoJsonContext}
               updateLengths={handlers.updateLengths}
               embedMode={state.embedMode}
               debugMode={state.debugMode}
@@ -281,6 +282,7 @@ AppLayout.propTypes = {
     downloadData: PropTypes.func,
     onMapMoved: PropTypes.func,
     onMapPositionChange: PropTypes.func,
+    needsCityGeoJsonContext: PropTypes.func,
     getMapViewport: PropTypes.func,
     forceUpdate: PropTypes.func,
     cancelDataLoad: PropTypes.func,

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -72,14 +72,17 @@ export default function AppLayout({
               toggleTheme={handlers.toggleTheme}
               loading={state.loading}
               cancelDataLoad={handlers.cancelDataLoad}
+              toggleDirectionsPanel={handlers.toggleDirectionsPanel}
+              triggerGeolocate={handlers.triggerGeolocate}
             />
           </header>
           {state.mapBootReady ? (
             <Map
               key={state.mapKey}
-              ref={(map) => {
+              ref={(mapComponent) => {
+                handlers.setMapComponentRef?.(mapComponent);
                 if (!IS_PROD && state.debugMode) {
-                  window.map = map;
+                  window.map = mapComponent;
                 }
               }}
               data={state.geoJson}
@@ -286,6 +289,8 @@ AppLayout.propTypes = {
     toggleTheme: PropTypes.func,
     updateLengths: PropTypes.func,
     setMapRef: PropTypes.func,
+    setMapComponentRef: PropTypes.func,
+    triggerGeolocate: PropTypes.func,
     onTrackingUserLocationChange: PropTypes.func,
     clearGlobalSearchPin: PropTypes.func,
     handleFavoritesChanged: PropTypes.func,
@@ -297,6 +302,7 @@ AppLayout.propTypes = {
     setToPoint: PropTypes.func,
     clearRoutePoints: PropTypes.func,
     onDirectionsPanelToggle: PropTypes.func,
+    toggleDirectionsPanel: PropTypes.func,
     setArea: PropTypes.func,
     closeAboutModal: PropTypes.func,
     openCityPicker: PropTypes.func,

--- a/src/CitySwitcherModal.css
+++ b/src/CitySwitcherModal.css
@@ -490,8 +490,8 @@ a.city-switcher-modal__cityBtn {
     flex-direction: row;
     align-items: center;
     gap: 8px;
-    padding-left: 14px;
-    padding-right: 14px;
+    padding-left: 8px;
+    padding-right: 8px;
     box-sizing: border-box;
   }
 

--- a/src/CitySwitcherModal.tsx
+++ b/src/CitySwitcherModal.tsx
@@ -1381,7 +1381,7 @@ function CitySwitcherModal({
         : labelsPt.length === 1
           ? `em ${labelsPt[0]}`
           : `em ${labelsPt.slice(0, -1).join(', ')} e ${labelsPt[labelsPt.length - 1]}`;
-    return IS_PROD ? `Buscar endereço ou local ${suffix}` : 'Buscar endereço ou local no mundo';
+    return IS_PROD ? `Buscar ${suffix}` : 'Buscar no mundo';
   }, []);
 
   const handlePlaceSuggestionPick = useCallback(

--- a/src/CommentModal.js
+++ b/src/CommentModal.js
@@ -9,13 +9,13 @@ import { getOsmUrl } from './utils/utils.js';
 const { TextArea } = Input;
 const { Text } = Typography;
 
-const DEFAULT_STATUS = 'Aberta';
-
 class CommentModal extends Component {
   defaultState = {
     text: '',
     tags: [],
     email: undefined,
+    website: '',
+    submitting: false,
   };
 
   constructor(props) {
@@ -25,6 +25,7 @@ class CommentModal extends Component {
     this.onTextChange = this.onTextChange.bind(this);
     this.onTagsChange = this.onTagsChange.bind(this);
     this.onEmailChange = this.onEmailChange.bind(this);
+    this.onWebsiteChange = this.onWebsiteChange.bind(this);
 
     this.state = this.defaultState;
   }
@@ -33,26 +34,35 @@ class CommentModal extends Component {
     this.setState(this.defaultState);
   }
 
-  handleOk = (e) => {
-    const { coords, location } = this.props;
+  handleOk = async () => {
+    if (this.state.submitting) return;
 
-    this.props.airtableDatabase
-      .create({
-        status: DEFAULT_STATUS,
+    const { coords, location } = this.props;
+    this.setState({ submitting: true });
+
+    try {
+      await this.props.airtableDatabase.create({
         latlong: `${coords.lat},${coords.lng}`,
         location: location,
         text: this.state.text,
         tags: this.state.tags,
         email: this.state.email,
-      })
-      .then(() => {
-        appNotification.success({
-          title: 'Novo comentário criado.',
-        });
-
-        this.props.afterCreate();
-        this.reset();
+        website: this.state.website,
       });
+
+      appNotification.success({
+        title: 'Novo comentário criado.',
+      });
+
+      this.props.afterCreate();
+      this.reset();
+    } catch {
+      appNotification.error({
+        title: 'Não foi possível enviar o comentário.',
+        description: 'Tente novamente em alguns instantes.',
+      });
+      this.setState({ submitting: false });
+    }
   };
 
   onTextChange = ({ target: { value } }) => {
@@ -64,6 +74,12 @@ class CommentModal extends Component {
   onEmailChange = ({ target: { value } }) => {
     this.setState({
       email: value,
+    });
+  };
+
+  onWebsiteChange = ({ target: { value } }) => {
+    this.setState({
+      website: value,
     });
   };
 
@@ -86,10 +102,11 @@ class CommentModal extends Component {
         onOk={this.handleOk}
         onCancel={this.props.onCancel}
         destroyOnHidden
-        // width={360}
         centered={true}
         okButtonProps={{
-          disabled: this.state.text.length === 0 || this.state.tags.length === 0,
+          disabled:
+            this.state.submitting || this.state.text.length === 0 || this.state.tags.length === 0,
+          loading: this.state.submitting,
         }}
         okText="Adicionar comentário"
         cancelText="Cancelar"
@@ -112,22 +129,6 @@ class CommentModal extends Component {
 
           <div>
             <Text className="text-white">Assunto</Text>
-
-            {/* <Select
-                            mode="multiple"
-                            allowClear
-                            style={{ width: '100%' }}
-                            placeholder="Selecione uma ou mais tags..."
-                            onChange={this.onTagsChange}
-                        >
-                            {
-                                this.props.tagsList.map(t =>
-                                    <Option key={t}>
-                                        {t}
-                                    </Option>
-                                )
-                            }
-                        </Select> */}
             <Checkbox.Group style={{ width: '100%' }} onChange={this.onTagsChange}>
               <Row>
                 {this.props.tagsList.map((t) => (
@@ -158,6 +159,19 @@ class CommentModal extends Component {
             <Input
               onChange={this.onEmailChange}
               placeholder="Opcional, somente visível para a equipe CicloMapa"
+            />
+          </div>
+
+          <div aria-hidden="true" className="absolute overflow-hidden" style={{ left: '-9999px' }}>
+            <label htmlFor="comment-website">Website</label>
+            <input
+              id="comment-website"
+              name="website"
+              type="text"
+              tabIndex={-1}
+              autoComplete="off"
+              value={this.state.website}
+              onChange={this.onWebsiteChange}
             />
           </div>
         </Space>

--- a/src/DirectionsPanel.css
+++ b/src/DirectionsPanel.css
@@ -7,8 +7,8 @@
   width: var(--spacing-panel-width);
   z-index: 1;
   transition:
-    transform var(--motion-duration-normal) ease-out,
-    opacity var(--motion-duration-normal) ease-out;
+    transform var(--motion-duration-slow) cubic-bezier(0.22, 1, 0.36, 1),
+    opacity var(--motion-duration-slow) cubic-bezier(0.22, 1, 0.36, 1);
   transform: translateY(-10%);
   opacity: 0;
   pointer-events: none;

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -1159,7 +1159,7 @@ class DirectionsPanel extends Component {
 
     return (
       <>
-        {(!IS_MOBILE || this.state.collapsed) && (
+        {IS_MOBILE && this.state.collapsed && (
           <div
             id="directionsPanelMobileButton"
             className={`directions-panel-button ${this.state.collapsed ? 'collapsed' : 'expanded'}`}

--- a/src/LayersBar.js
+++ b/src/LayersBar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { IS_MOBILE, TOPBAR_HEIGHT, PMTILES_EXCLUDED_LAYER_NAMES } from './config/constants.js';
+import { IS_MOBILE, TOPBAR_HEIGHT } from './config/constants.js';
 
 import bikeparkingIcon from './img/icons/poi-bikeparking-mini.png';
 import bikeparkingIconLight from './img/icons/poi-bikeparking-mini--light.png';
@@ -15,13 +15,10 @@ class LayersBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      outrasExpanded: false,
       pontosExpanded: false,
       ciclowaysExpanded: false,
-      outrasAnimating: false,
       pontosAnimating: false,
       ciclowaysAnimating: false,
-      outrasExpanding: false,
       pontosExpanding: false,
       ciclowaysExpanding: false,
     };
@@ -44,12 +41,7 @@ class LayersBar extends Component {
           l.name === 'Ciclofaixa' ||
           l.name === 'Ciclorrota'
       ),
-      // Residenciais, Trilhas e Proibidas are omitted from PMTiles — hide on mobile.
-      outras: activeLayers.filter(
-        (l) =>
-          (l.name === 'Baixa velocidade' || l.name === 'Trilha' || l.name === 'Proibido') &&
-          !PMTILES_EXCLUDED_LAYER_NAMES.has(l.name)
-      ),
+      // Baixa velocidade / Trilha / Proibido are omitted from PMTiles, so no "outras" category on mobile.
     };
 
     return categories;
@@ -265,9 +257,6 @@ class LayersBar extends Component {
       cicloways: {
         label: 'Vias cicláveis',
       },
-      outras: {
-        label: 'Outras vias',
-      },
     };
 
     return (
@@ -363,52 +352,6 @@ class LayersBar extends Component {
                 label: layer.shortName || layer.displayName || layer.name,
                 shouldMergeWithNext,
                 isAnimated: this.state.pontosAnimating,
-              });
-            });
-          })()}
-
-          {/* Outras category button (last) */}
-          {(() => {
-            const config = categoryConfig.outras;
-            const hasLayers = categories.outras.length > 0;
-            const allLayersDeactivated =
-              hasLayers && categories.outras.every((layer) => !layer.isActive);
-
-            // Only show Outras button if all layers are deactivated
-            if (!hasLayers || !allLayersDeactivated) return null;
-
-            return this.renderLayerButton({
-              id: 'outras',
-              onClick: () => this.toggleCategoryExpansion('outras'),
-              isActive: false, // Always false since we only show when all are deactivated
-              icon: config.icon,
-              lineStyle: config.style,
-              label: config.label,
-              isAnimated: this.state.outrasAnimating,
-              isCategoryPill: true,
-            });
-          })()}
-
-          {/* Individual Outras layers - show when any are active or when expanded */}
-          {(() => {
-            const hasActiveOutrasLayers = categories.outras.some((layer) => layer.isActive);
-            const shouldShowIndividual = hasActiveOutrasLayers || this.state.outrasExpanded;
-
-            if (!shouldShowIndividual) return null;
-
-            return categories.outras.map((layer, index) => {
-              const displayName = layer.displayName || layer.name;
-              const shouldMergeWithNext = index < categories.outras.length - 1;
-
-              return this.renderLayerButton({
-                id: layer.id,
-                onClick: () => this.toggleCategoryLayer('outras', layer.id),
-                isActive: layer.isActive,
-                lineStyle: layer.style,
-                label: displayName,
-                className: 'ml-2',
-                shouldMergeWithNext,
-                isAnimated: this.state.outrasAnimating,
               });
             });
           })()}

--- a/src/LayersBar.js
+++ b/src/LayersBar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { IS_MOBILE, TOPBAR_HEIGHT } from './config/constants.js';
+import { IS_MOBILE, TOPBAR_HEIGHT, PMTILES_EXCLUDED_LAYER_NAMES } from './config/constants.js';
 
 import bikeparkingIcon from './img/icons/poi-bikeparking-mini.png';
 import bikeparkingIconLight from './img/icons/poi-bikeparking-mini--light.png';
@@ -44,8 +44,11 @@ class LayersBar extends Component {
           l.name === 'Ciclofaixa' ||
           l.name === 'Ciclorrota'
       ),
+      // Residenciais, Trilhas e Proibidas are omitted from PMTiles — hide on mobile.
       outras: activeLayers.filter(
-        (l) => l.name === 'Baixa velocidade' || l.name === 'Trilha' || l.name === 'Proibido'
+        (l) =>
+          (l.name === 'Baixa velocidade' || l.name === 'Trilha' || l.name === 'Proibido') &&
+          !PMTILES_EXCLUDED_LAYER_NAMES.has(l.name)
       ),
     };
 

--- a/src/LayersLegendModal.js
+++ b/src/LayersLegendModal.js
@@ -13,6 +13,7 @@ import { HiOutlineXMark } from 'react-icons/hi2';
 import {
   ENABLE_COMMENTS,
   IS_MOBILE,
+  PMTILES_EXCLUDED_LAYER_NAMES,
   ROUTE_COLORS,
   ROUTE_INFRASTRUCTURE_QUALITY_WEIGHTS,
 } from './config/constants.js';
@@ -181,9 +182,7 @@ class LayersLegendModal extends Component {
           l.name === 'Ciclorrota')
     );
     const outrasViasLayers = activeLayers.filter(
-      (l) =>
-        l.type === 'way' &&
-        (l.name === 'Baixa velocidade' || l.name === 'Trilha' || l.name === 'Proibido')
+      (l) => l.type === 'way' && PMTILES_EXCLUDED_LAYER_NAMES.has(l.name)
     );
 
     const categoryContainerClasses = 'grid grid-cols-1 items-stretch gap-4 md:grid-cols-2';
@@ -201,8 +200,11 @@ class LayersLegendModal extends Component {
       }`;
     };
 
-    const { visible } = this.props;
+    const { visible, isDarkMode } = this.props;
     const deferLegendImage = IS_MOBILE && !visible;
+    const mobileUnavailableNoteClass = isDarkMode
+      ? 'border border-amber-400/50 bg-amber-500/20 text-amber-100'
+      : 'border border-amber-700/25 bg-amber-100 text-amber-950';
 
     const renderLayer = (layer) => (
       <div
@@ -260,6 +262,14 @@ class LayersLegendModal extends Component {
                 </InfrastructureBadge>
               )}
             </div>
+            {PMTILES_EXCLUDED_LAYER_NAMES.has(layer.name) && (
+              <p
+                className={`mb-0 mt-3 rounded-lg px-3 py-2.5 text-sm font-semibold leading-snug ${mobileUnavailableNoteClass}`}
+                role="note"
+              >
+                Não exibida no mapa na versão para celular.
+              </p>
+            )}
             <p className="mb-0 mt-2 text-sm leading-normal text-gray-400">{layer.description}</p>
           </div>
         </div>

--- a/src/LayersPanel.js
+++ b/src/LayersPanel.js
@@ -191,7 +191,7 @@ class LayersPanel extends Component {
                         <span
                           className="w-full"
                           style={{
-                            height: 6,
+                            height: 4,
                             background:
                               l.style.lineStyle === 'solid'
                                 ? l.style.lineColor
@@ -205,7 +205,12 @@ class LayersPanel extends Component {
                           }}
                         ></span>
                       ) : (
-                        <img className="h-4" src={iconsMap[l.icon]} alt="" />
+                        <img
+                          className="h-4"
+                          style={{ borderRadius: '4px' }}
+                          src={iconsMap[l.icon]}
+                          alt=""
+                        />
                       )}
                     </span>
 

--- a/src/LayersPanel.js
+++ b/src/LayersPanel.js
@@ -10,7 +10,7 @@ import { IconSignal1, IconSignal2, IconSignal3 } from './components/ProtectionSi
 
 import './LayersPanel.css';
 
-import { IS_MOBILE } from './config/constants.js';
+import { IS_MOBILE, PMTILES_EXCLUDED_LAYER_NAMES } from './config/constants.js';
 
 import commentIcon from './img/icons/poi-comment-flat.png';
 import bikeparkingIcon from './img/icons/poi-bikeparking@2x.png';
@@ -42,7 +42,7 @@ const VIAS_CICLAVEIS_LAYER_NAMES = new Set([
   'Ciclorrota',
 ]);
 
-const OUTRAS_VIAS_LAYER_NAMES = new Set(['Baixa velocidade', 'Trilha', 'Proibido']);
+const OUTRAS_VIAS_LAYER_NAMES = PMTILES_EXCLUDED_LAYER_NAMES;
 
 /** @returns {string | null} LayersLegendModal section id */
 const getLegendSectionForLayer = (layer) => {
@@ -168,6 +168,7 @@ class LayersPanel extends Component {
         >
           {layers
             .filter((l) => (embedMode ? l.isActive : true))
+            .filter((l) => !IS_MOBILE || !PMTILES_EXCLUDED_LAYER_NAMES.has(l.name))
             .map((l) => (
               <Popover
                 placement="left"

--- a/src/Map.css
+++ b/src/Map.css
@@ -118,6 +118,7 @@ body.theme-dark .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-group {
     .mapboxgl-ctrl-bottom-right
     .mapboxgl-ctrl-group:has(.mapboxgl-ctrl-geolocate) {
     margin: 0 8px 74px 0;
+    transition: transform var(--motion-duration-slow, 500ms) cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   /* Above open panel: planning form vs route results (heights differ) */
@@ -130,5 +131,13 @@ body.theme-dark .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-group {
     .mapboxgl-ctrl-bottom-right
     .mapboxgl-ctrl-group:has(.mapboxgl-ctrl-geolocate) {
     transform: translateY(-172px);
+  }
+}
+
+@media (max-width: 480px) and (prefers-reduced-motion: reduce) {
+  #ciclomapa:not(.hideUI)
+    .mapboxgl-ctrl-bottom-right
+    .mapboxgl-ctrl-group:has(.mapboxgl-ctrl-geolocate) {
+    transition: none;
   }
 }

--- a/src/Map.css
+++ b/src/Map.css
@@ -106,12 +106,20 @@ body.theme-dark .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-group {
   margin-right: 12px;
 }
 
-/* Route FAB vs geolocate: geo high (ex-route), route low (ex-geo) */
-.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-group:has(.mapboxgl-ctrl-geolocate) {
-  margin: 0 8px 74px 0;
+/* Desktop: Mapbox geolocate stays mounted for trigger(), but the visible control is in the topbar. */
+.mapboxgl-ctrl-geolocate-host--topbar {
+  display: none !important;
 }
 
+/* Route FAB vs geolocate: geo high, route low — mobile only (desktop geo+route live in the topbar).
+   #ciclomapa + :not(.hideUI) so this beats App.less chrome transitions without stealing hideUI motion. */
 @media (max-width: 480px) {
+  #ciclomapa:not(.hideUI)
+    .mapboxgl-ctrl-bottom-right
+    .mapboxgl-ctrl-group:has(.mapboxgl-ctrl-geolocate) {
+    margin: 0 8px 74px 0;
+  }
+
   /* Above open panel: planning form vs route results (heights differ) */
   #ciclomapa:has(#directionsPanel.directions-panel-open--planning)
     .mapboxgl-ctrl-bottom-right

--- a/src/Map.js
+++ b/src/Map.js
@@ -49,7 +49,6 @@ import { arrowIconsByLayer, arrowIcons, arrowSdf, iconsMap } from './features/ma
 import { reverseGeocodePlace } from './features/map/mapboxGeocoding.js';
 import { flyMapTo } from './features/map/mapCamera.js';
 import userLocationCache from './features/geolocation/userLocationCache.js';
-import { startDataLoad, finishDataLoad } from './dev/dataLoadTracker.js';
 
 import './Map.css';
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -5,7 +5,6 @@ import mapboxgl from 'mapbox-gl';
 import turfBbox from '@turf/bbox';
 import turfCircle from '@turf/circle';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { PmTilesSource } from 'mapbox-pmtiles';
 
 import { startDataLoad, finishDataLoad } from './dev/dataLoadTracker.js';
 import {
@@ -157,6 +156,7 @@ class Map extends Component {
 
     // Track geojson feature IDs to hide from pmtiles layers
     this.geojsonFeatureIds = new Set();
+    this.layersInitialized = false;
 
     // Create debounced map state sync function (only syncs if place name has been consistent for 1+ second).
     // geocodeRequestTime is the timestamp of the reverseGeocode call that produced the placeName;
@@ -305,8 +305,8 @@ class Map extends Component {
       ),
     ];
 
-    // For pmtiles layers, combine with geojson feature ID hiding filter
-    if (sourceId === 'pmtiles-source' && this.geojsonFeatureIds.size > 0) {
+    // For pmtiles layers, hide features already shown via GeoJSON (dual-source mode only).
+    if (USE_GEOJSON_SOURCE && sourceId === 'pmtiles-source' && this.geojsonFeatureIds.size > 0) {
       const idsToHide = Array.from(this.geojsonFeatureIds);
       const hideFilter = [
         '!',
@@ -323,6 +323,8 @@ class Map extends Component {
   }
 
   hideGeoJsonFromPmtiles(geoJsonData) {
+    if (!USE_GEOJSON_SOURCE) return;
+
     // Extract feature IDs from geojson data
     const featureIds = new Set();
 
@@ -427,6 +429,8 @@ class Map extends Component {
   }
 
   initPOILayerForSource(l, sourceId) {
+    if (!this.map.getSource(sourceId)) return;
+
     const filters = this.convertFilterToMapboxFilter(l, sourceId);
 
     const sourceLayer = sourceId === 'osmdata' ? '' : 'default';
@@ -537,54 +541,44 @@ class Map extends Component {
         return;
       }
 
-      if (interactionType === 'mouseenter' && e.features.length > 0) {
-        self.map.getCanvas().style.cursor = 'pointer';
-
-        if (self.hoveredPOI) {
-          self.map.setFeatureState(
-            {
-              source: sourceId,
-              sourceLayer: sourceLayer,
-              id: self.hoveredPOI,
-            },
-            { hover: false }
-          );
-        }
-        self.hoveredPOI = e.features[0].id;
+      const clearHoveredPoi = () => {
+        if (self.hoveredPOI == null) return;
         self.map.setFeatureState(
           {
             source: sourceId,
             sourceLayer: sourceLayer,
             id: self.hoveredPOI,
           },
+          { hover: false }
+        );
+      };
+
+      if (interactionType === 'mouseenter' && e.features.length > 0) {
+        const feature = e.features[0];
+        const featureId = feature.id ?? feature.properties?.id ?? feature.properties?.['@id'];
+        if (featureId == null) return;
+
+        self.map.getCanvas().style.cursor = 'pointer';
+        clearHoveredPoi();
+        self.hoveredPOI = featureId;
+        self.map.setFeatureState(
+          {
+            source: sourceId,
+            sourceLayer: sourceLayer,
+            id: featureId,
+          },
           { hover: true }
         );
       } else if (interactionType === 'mouseleave') {
-        if (self.hoveredPOI) {
+        if (self.hoveredPOI != null) {
           self.map.getCanvas().style.cursor = '';
-
-          self.map.setFeatureState(
-            {
-              source: sourceId,
-              sourceLayer: sourceLayer,
-              id: self.hoveredPOI,
-            },
-            { hover: false }
-          );
+          clearHoveredPoi();
         }
         self.hoveredPOI = null;
       } else if (interactionType === 'click') {
         if (e.features.length > 0 && !e.originalEvent.defaultPrevented) {
-          if (self.hoveredPOI) {
-            self.map.setFeatureState(
-              {
-                source: sourceId,
-                sourceLayer: sourceLayer,
-                id: self.hoveredPOI,
-              },
-              { hover: false }
-            );
-          }
+          clearHoveredPoi();
+          self.hoveredPOI = null;
           self.popups.showPOIPopup(e, iconsMap[l.icon + '-2x'], l.icon);
           self.focusFeatureOnMobile(e.features[0]);
         }
@@ -895,6 +889,8 @@ class Map extends Component {
   }
 
   initCyclepathLayerForSource(l, sourceId) {
+    if (!this.map.getSource(sourceId)) return;
+
     const filters = this.convertFilterToMapboxFilter(l, sourceId);
 
     const layerUnderneathName = this.getLayerUnderneathName(this.map);
@@ -1412,24 +1408,13 @@ class Map extends Component {
       const pmtilesLoadToken = startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
       try {
         const PMTILES_URL = process.env.REACT_APP_PMTILES_URL + PMTILES_FILENAME;
-        console.log('Loading PMTiles from S3:', PMTILES_URL);
-
-        const header = await PmTilesSource.getHeader(PMTILES_URL);
-        console.log(
-          'PMTiles loaded - bounds:',
-          [header.minLon, header.minLat, header.maxLon, header.maxLat],
-          'zoom:',
-          header.minZoom + '-' + header.maxZoom
-        );
-
-        const bounds = [header.minLon, header.minLat, header.maxLon, header.maxLat];
+        console.log('Loading PMTiles (native vector source):', PMTILES_URL);
 
         this.map.addSource('pmtiles-source', {
-          type: PmTilesSource.SOURCE_TYPE,
+          type: 'vector',
           url: PMTILES_URL,
-          minzoom: header.minZoom,
-          maxzoom: header.maxZoom,
-          bounds: bounds,
+          lineMetrics: true,
+          promoteId: 'id',
         });
 
         console.log('PMTiles source added successfully');
@@ -1446,7 +1431,7 @@ class Map extends Component {
           },
         });
       } catch (error) {
-        console.error('Error setting up PmTiles for cyclepaths:', error);
+        console.error('Error setting up PMTiles source:', error);
         this.pmtilesLoadedSuccessfully = false;
         finishDataLoad('pmtiles', {
           token: pmtilesLoadToken,
@@ -1470,53 +1455,58 @@ class Map extends Component {
   async initGeojsonLayers(layers) {
     const map = this.map;
 
-    // @todo Better way to check if layers are already initialized
-    if (!map.getSource('osmdata')) {
-      await this.initializeDataSources();
+    if (this.layersInitialized) {
+      console.warn('Map layers already initialized.');
+      return;
+    }
 
-      if (!map.getSource('commentsSrc')) {
-        map.addSource('commentsSrc', {
-          type: 'geojson',
-          data: {
-            type: 'FeatureCollection',
-            features: [],
-          },
-          generateId: true,
-        });
-      }
+    await this.initializeDataSources();
 
-      if (!map.getSource('favoritesSrc')) {
-        map.addSource('favoritesSrc', {
-          type: 'geojson',
-          data: { type: 'FeatureCollection', features: [] },
-        });
-      }
+    if (!map.getSource('commentsSrc')) {
+      map.addSource('commentsSrc', {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [],
+        },
+        generateId: true,
+      });
+    }
 
-      // layers.json is ordered from most to least important, but we
-      //   want the most important ones to be on top so we add in reverse.
-      // Slice is used here to don't destructively reverse the original array.
-      layers
-        .slice()
-        .reverse()
-        .forEach((l) => {
-          if (!l.type || l.type === 'way') {
-            if (this.pmtilesLoadedSuccessfully) {
-              this.initCyclepathLayerForSource(l, 'pmtiles-source');
-            }
+    if (!map.getSource('favoritesSrc')) {
+      map.addSource('favoritesSrc', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      });
+    }
 
+    // layers.json is ordered from most to least important, but we
+    //   want the most important ones to be on top so we add in reverse.
+    // Slice is used here to don't destructively reverse the original array.
+    layers
+      .slice()
+      .reverse()
+      .forEach((l) => {
+        if (!l.type || l.type === 'way') {
+          if (this.pmtilesLoadedSuccessfully) {
+            this.initCyclepathLayerForSource(l, 'pmtiles-source');
+          }
+
+          if (USE_GEOJSON_SOURCE) {
             this.initCyclepathLayerForSource(l, 'osmdata');
-          } else if (l.type === 'poi' && l.filters) {
-            // Mapbox doesn't support symbol layers for pmtiles
-            // if (this.pmtilesLoadedSuccessfully) {
-            //     this.initPOILayerForSource(l, 'pmtiles-source');
-            // }
+          }
+        } else if (l.type === 'poi' && l.filters) {
+          if (this.pmtilesLoadedSuccessfully && !USE_GEOJSON_SOURCE) {
+            this.initPOILayerForSource(l, 'pmtiles-source');
+          }
 
+          if (USE_GEOJSON_SOURCE) {
             this.initPOILayerForSource(l, 'osmdata');
           }
-        });
-    } else {
-      console.warn('Map layers already initialized.');
-    }
+        }
+      });
+
+    this.layersInitialized = true;
 
     if (map.getLayer('mapbox-satellite')) {
       map.setLayoutProperty(
@@ -2646,9 +2636,6 @@ class Map extends Component {
     }
 
     mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
-
-    // Register PmTiles source type
-    mapboxgl.Style.setSourceType(PmTilesSource.SOURCE_TYPE, PmTilesSource);
 
     try {
       console.log('Creating Mapbox map...');

--- a/src/Map.js
+++ b/src/Map.js
@@ -451,12 +451,20 @@ class Map extends Component {
         type: 'circle',
         maxzoom: l.zoomThreshold,
         paint: {
-          'circle-radius': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 2, 15, 4],
+          'circle-radius': [
+            'interpolate',
+            ['exponential', 1.5],
+            ['zoom'],
+            12,
+            IS_MOBILE ? 1 : 2,
+            15,
+            4,
+          ],
           'circle-color': adjustColorBrightness(
             l.style.textColor,
             this.props.isDarkMode ? 0.2 : 0.2
           ),
-          'circle-stroke-width': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 0, 15, 2],
+          'circle-stroke-width': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 0.5, 15, 2],
           'circle-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.7, 1.0],
           'circle-stroke-color': this.props.isDarkMode
             ? MAP_COLORS.DARK.STROKE

--- a/src/Map.js
+++ b/src/Map.js
@@ -161,11 +161,6 @@ class Map extends Component {
     this.debouncedMapStateSync = debounce((placeName, geocodeRequestTime) => {
       console.debug('Syncing map state with consistent place:', placeName);
       this.syncMapState(placeName, geocodeRequestTime);
-      // Dimming the city label while a new one resolves only makes sense on desktop,
-      // where the label shows the actual city name (mobile shows a search placeholder).
-      if (!IS_MOBILE) {
-        document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
-      }
     }, 1000);
   }
 
@@ -248,10 +243,6 @@ class Map extends Component {
                   '), cancelling previous sync and starting new timer'
               );
 
-              if (!IS_MOBILE) {
-                document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 0.5');
-              }
-
               // Different place - cancel previous debounced call and start new timer
               this.debouncedMapStateSync.cancel();
               this.lastGeocodedPlaceName = currentPlaceName;
@@ -264,7 +255,6 @@ class Map extends Component {
         });
     } else {
       console.debug('Map zoom is below auto change area zoom threshold');
-      // document.querySelector('.city-picker span').setAttribute('style','opacity: 0.5');
     }
   }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -49,6 +49,7 @@ import { arrowIconsByLayer, arrowIcons, arrowSdf, iconsMap } from './features/ma
 import { reverseGeocodePlace } from './features/map/mapboxGeocoding.js';
 import { flyMapTo } from './features/map/mapCamera.js';
 import userLocationCache from './features/geolocation/userLocationCache.js';
+import { startDataLoad, finishDataLoad } from './dev/dataLoadTracker.js';
 
 import './Map.css';
 
@@ -1322,9 +1323,10 @@ class Map extends Component {
     await this.awaitStyleReady();
 
     if (USE_PMTILES_SOURCE) {
-      const pmtilesLoadToken = startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
+      const PMTILES_URL = process.env.REACT_APP_PMTILES_URL + PMTILES_FILENAME;
+      startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
+
       try {
-        const PMTILES_URL = process.env.REACT_APP_PMTILES_URL + PMTILES_FILENAME;
         console.log('Loading PMTiles (native vector source):', PMTILES_URL);
 
         this.map.addSource('pmtiles-source', {
@@ -1337,24 +1339,28 @@ class Map extends Component {
         console.log('PMTiles source added successfully');
         this.pmtilesLoadedSuccessfully = true;
 
-        // Hide geojson features from pmtiles layers
-        this.hideGeoJsonFromPmtiles(this.props.data);
-
-        finishDataLoad('pmtiles', {
-          token: pmtilesLoadToken,
-          meta: {
-            file: PMTILES_FILENAME,
-            zoom: `${header.minZoom}-${header.maxZoom}`,
-          },
-        });
+        // addSource() only registers the tile source — actual tiles are fetched lazily,
+        // so we listen once for the first successful load or failure to report real status.
+        const onSourceData = (e) => {
+          if (e.sourceId === 'pmtiles-source' && e.isSourceLoaded) {
+            this.map.off('sourcedata', onSourceData);
+            this.map.off('error', onPmtilesError);
+            finishDataLoad('pmtiles', { meta: { file: PMTILES_FILENAME } });
+          }
+        };
+        const onPmtilesError = (e) => {
+          if (e.sourceId === 'pmtiles-source') {
+            this.map.off('sourcedata', onSourceData);
+            this.map.off('error', onPmtilesError);
+            finishDataLoad('pmtiles', { error: e.error, meta: { file: PMTILES_FILENAME } });
+          }
+        };
+        this.map.on('sourcedata', onSourceData);
+        this.map.on('error', onPmtilesError);
       } catch (error) {
         console.error('Error setting up PMTiles source:', error);
         this.pmtilesLoadedSuccessfully = false;
-        finishDataLoad('pmtiles', {
-          token: pmtilesLoadToken,
-          error,
-          meta: { file: PMTILES_FILENAME },
-        });
+        finishDataLoad('pmtiles', { error, meta: { file: PMTILES_FILENAME } });
       }
     }
   }

--- a/src/Map.js
+++ b/src/Map.js
@@ -216,6 +216,13 @@ class Map extends Component {
       return;
     }
 
+    // Reverse geocoding here is only needed to keep the area/URL in sync while the
+    // analytics sidebar or routes panel is open (they depend on knowing the current
+    // area). Otherwise skip the Mapbox request entirely - it was firing on every pan.
+    if (!this.props.needsCityGeoJsonContext?.()) {
+      return;
+    }
+
     if (this.map.getZoom() > MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD) {
       const center = this.map.getCenter();
       // Capture when this geocode request was initiated so App can distinguish stale
@@ -536,7 +543,9 @@ class Map extends Component {
     if (this.map.getLayer('boundary-layer')) this.map.removeLayer('boundary-layer');
     if (this.map.getSource('boundaryLineSrc')) this.map.removeSource('boundaryLineSrc');
 
-    if (!ENABLE_BOUNDARY_LAYER) {
+    // Same gate as live area geocoding / deferred GeoJSON: only draw while Analytics
+    // or Routing actually needs city context. Closing both panels clears the layer above.
+    if (!ENABLE_BOUNDARY_LAYER || !this.props.needsCityGeoJsonContext?.()) {
       return;
     }
 
@@ -2696,9 +2705,10 @@ class Map extends Component {
     this.initializeMapAfterStyleLoad();
 
     // Initialize map center. Match onMapMoveEnded: mobile never reverse-geocodes
-    // (no live city label), so skip the Mapbox request on startup too.
+    // (no live city label), so skip the Mapbox request on startup too. Also skip
+    // when we already know the area (city picker/route) - no need to re-derive it.
     const shouldInitializeArea =
-      !IS_MOBILE && this.props.zoom >= MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD;
+      !IS_MOBILE && !this.props.location && this.props.zoom >= MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD;
     if (shouldInitializeArea) {
       this.reverseGeocode([this.props.lng, this.props.lat])
         .then((result) => {

--- a/src/Map.js
+++ b/src/Map.js
@@ -9,7 +9,6 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import { startDataLoad, finishDataLoad } from './dev/dataLoadTracker.js';
 import {
   MAPBOX_ACCESS_TOKEN,
-  USE_GEOJSON_SOURCE,
   USE_PMTILES_SOURCE,
   INTERACTIVE_LAYERS_ZOOM_THRESHOLD,
   ENABLE_COMMENTS,
@@ -89,7 +88,6 @@ const MISSING_BASEMAP_IMAGES = new Set([
 
 /** Geo sources for app data layers; basemap (e.g. composite) is everything else. */
 const CICLOMAPA_DATA_SOURCES = new Set([
-  'osmdata',
   'pmtiles-source',
   'commentsSrc',
   'favoritesSrc',
@@ -154,8 +152,6 @@ class Map extends Component {
       comments: [],
     };
 
-    // Track geojson feature IDs to hide from pmtiles layers
-    this.geojsonFeatureIds = new Set();
     this.layersInitialized = false;
 
     // Create debounced map state sync function (only syncs if place name has been consistent for 1+ second).
@@ -165,7 +161,11 @@ class Map extends Component {
     this.debouncedMapStateSync = debounce((placeName, geocodeRequestTime) => {
       console.debug('Syncing map state with consistent place:', placeName);
       this.syncMapState(placeName, geocodeRequestTime);
-      document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
+      // Dimming the city label while a new one resolves only makes sense on desktop,
+      // where the label shows the actual city name (mobile shows a search placeholder).
+      if (!IS_MOBILE) {
+        document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 1');
+      }
     }, 1000);
   }
 
@@ -248,7 +248,9 @@ class Map extends Component {
                   '), cancelling previous sync and starting new timer'
               );
 
-              document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 0.5');
+              if (!IS_MOBILE) {
+                document.querySelector('.city-picker span')?.setAttribute('style', 'opacity: 0.5');
+              }
 
               // Different place - cancel previous debounced call and start new timer
               this.debouncedMapStateSync.cancel();
@@ -295,8 +297,8 @@ class Map extends Component {
     }
   }
 
-  convertFilterToMapboxFilter(l, sourceId = null) {
-    const baseFilter = [
+  convertFilterToMapboxFilter(l) {
+    return [
       'any',
       ...l.filters.map((f) =>
         typeof f[0] === 'string'
@@ -304,78 +306,6 @@ class Map extends Component {
           : ['all', ...f.map((f2) => ['==', ['get', f2[0]], f2[1]])]
       ),
     ];
-
-    // For pmtiles layers, hide features already shown via GeoJSON (dual-source mode only).
-    if (USE_GEOJSON_SOURCE && sourceId === 'pmtiles-source' && this.geojsonFeatureIds.size > 0) {
-      const idsToHide = Array.from(this.geojsonFeatureIds);
-      const hideFilter = [
-        '!',
-        [
-          'any',
-          ['in', ['get', '@id'], ['literal', idsToHide]],
-          ['in', ['get', 'id'], ['literal', idsToHide]],
-        ],
-      ];
-      return ['all', baseFilter, hideFilter];
-    }
-
-    return baseFilter;
-  }
-
-  hideGeoJsonFromPmtiles(geoJsonData) {
-    if (!USE_GEOJSON_SOURCE) return;
-
-    // Extract feature IDs from geojson data
-    const featureIds = new Set();
-
-    if (geoJsonData && geoJsonData.features) {
-      geoJsonData.features.forEach((feature) => {
-        if (feature.id !== undefined) {
-          featureIds.add(feature.id);
-        }
-      });
-    }
-
-    this.geojsonFeatureIds = featureIds;
-
-    // Update filters for existing pmtiles layers
-    if (!this.map || !this.pmtilesLoadedSuccessfully) {
-      return;
-    }
-
-    this.props.layers.forEach((layer) => {
-      if (!layer.type || layer.type === 'way') {
-        const layerId = layer.id + '--pmtiles';
-        if (this.map.getLayer(layerId)) {
-          const newFilter = this.convertFilterToMapboxFilter(layer, 'pmtiles-source');
-          this.map.setFilter(layerId, newFilter);
-        }
-        const routesActiveLayerId = layer.id + '--routes-active--pmtiles';
-        if (this.map.getLayer(routesActiveLayerId)) {
-          const newFilter = this.convertFilterToMapboxFilter(layer, 'pmtiles-source');
-          this.map.setFilter(routesActiveLayerId, newFilter);
-        }
-      } else if (layer.type === 'poi' && layer.filters) {
-        const layerId = layer.id + '--pmtiles';
-        const circlesLayerId = layerId + 'circles';
-        const polygonLayerId = layerId + 'polygon';
-
-        if (this.map.getLayer(circlesLayerId)) {
-          const newFilter = this.convertFilterToMapboxFilter(layer, 'pmtiles-source');
-          this.map.setFilter(circlesLayerId, newFilter);
-        }
-
-        if (this.map.getLayer(layerId)) {
-          const newFilter = this.convertFilterToMapboxFilter(layer, 'pmtiles-source');
-          this.map.setFilter(layerId, newFilter);
-        }
-
-        if (this.map.getLayer(polygonLayerId)) {
-          const newFilter = this.convertFilterToMapboxFilter(layer, 'pmtiles-source');
-          this.map.setFilter(polygonLayerId, newFilter);
-        }
-      }
-    });
   }
 
   getLayerUnderneathName(map) {
@@ -431,7 +361,7 @@ class Map extends Component {
   initPOILayerForSource(l, sourceId) {
     if (!this.map.getSource(sourceId)) return;
 
-    const filters = this.convertFilterToMapboxFilter(l, sourceId);
+    const filters = this.convertFilterToMapboxFilter(l);
 
     const sourceLayer = sourceId === 'osmdata' ? '' : 'default';
     const sourceSuffix = sourceId === 'osmdata' ? '' : '--pmtiles';
@@ -898,7 +828,7 @@ class Map extends Component {
   initCyclepathLayerForSource(l, sourceId) {
     if (!this.map.getSource(sourceId)) return;
 
-    const filters = this.convertFilterToMapboxFilter(l, sourceId);
+    const filters = this.convertFilterToMapboxFilter(l);
 
     const layerUnderneathName = this.getLayerUnderneathName(this.map);
     const self = this;
@@ -926,57 +856,55 @@ class Map extends Component {
     // };
 
     // Interactive layer is wider than the actual layer to improve usability
-    if (sourceId === 'osmdata') {
-      this.map.addLayer(
-        {
-          id: interactiveLayerId,
-          type: 'line',
-          source: sourceId,
-          'source-layer': sourceLayer,
-          filter: filters,
-          paint: {
-            'line-opacity': [
+    this.map.addLayer(
+      {
+        id: interactiveLayerId,
+        type: 'line',
+        source: sourceId,
+        'source-layer': sourceLayer,
+        filter: filters,
+        paint: {
+          'line-opacity': [
+            'case',
+            ['boolean', ['feature-state', 'selected'], false],
+            1, // Selected
+            0,
+          ],
+          'line-offset': [
+            'interpolate',
+            ['exponential', 1.5],
+            ['zoom'],
+            10,
+            [
               'case',
-              ['boolean', ['feature-state', 'selected'], false],
-              1, // Selected
+              ['==', ['get', 'cycleway:right'], 'lane'],
+              Math.max(1, l.style.lineWidth / 4),
+              ['==', ['get', 'cycleway:left'], 'lane'],
+              Math.min(-1, -l.style.lineWidth / 4),
               0,
             ],
-            'line-offset': [
-              'interpolate',
-              ['exponential', 1.5],
-              ['zoom'],
-              10,
-              [
-                'case',
-                ['==', ['get', 'cycleway:right'], 'lane'],
-                Math.max(1, l.style.lineWidth / 4),
-                ['==', ['get', 'cycleway:left'], 'lane'],
-                Math.min(-1, -l.style.lineWidth / 4),
-                0,
-              ],
-              18,
-              [
-                'case',
-                ['==', ['get', 'cycleway:right'], 'lane'],
-                l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER,
-                ['==', ['get', 'cycleway:left'], 'lane'],
-                -l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER,
-                0,
-              ],
+            18,
+            [
+              'case',
+              ['==', ['get', 'cycleway:right'], 'lane'],
+              l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER,
+              ['==', ['get', 'cycleway:left'], 'lane'],
+              -l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER,
+              0,
             ],
-            'line-color': adjustColorBrightness(
-              l.style.lineColor,
-              this.props.isDarkMode ? -0.7 : 0.7
-            ),
-            'line-width': 20,
-          },
-          layout: {
-            'line-elevation-reference': 'ground',
-          },
+          ],
+          'line-color': adjustColorBrightness(
+            l.style.lineColor,
+            this.props.isDarkMode ? -0.7 : 0.7
+          ),
+          'line-width': 20,
         },
-        layerUnderneathName
-      );
-    }
+        layout: {
+          'line-elevation-reference': 'ground',
+        },
+      },
+      layerUnderneathName
+    );
 
     this.map.addLayer(
       {
@@ -1042,81 +970,79 @@ class Map extends Component {
       layerUnderneathName
     );
 
-    if (sourceId === 'osmdata') {
-      const arrowLayerId = normalLayerId + '--arrows';
-      const arrowBase = arrowIconsByLayer[l.name];
-      const useSdf = !arrowBase;
-      const arrowIconName = useSdf
-        ? 'arrowSdf'
-        : this.props.isDarkMode
-          ? arrowBase
-          : `${arrowBase}--light`;
+    const arrowLayerId = normalLayerId + '--arrows';
+    const arrowBase = arrowIconsByLayer[l.name];
+    const useSdf = !arrowBase;
+    const arrowIconName = useSdf
+      ? 'arrowSdf'
+      : this.props.isDarkMode
+        ? arrowBase
+        : `${arrowBase}--light`;
 
-      this.map.addLayer(
-        {
-          id: arrowLayerId,
-          type: 'symbol',
-          source: sourceId,
-          'source-layer': sourceLayer,
-          filter: filters,
-          minzoom: 12,
-          layout: {
-            'symbol-placement': 'line',
-            'symbol-spacing': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 20, 16, 80],
-            'icon-image': arrowIconName,
-            'icon-size': [
-              'interpolate',
-              ['exponential', 1.5],
-              ['zoom'],
-              10,
-              (Math.max(1, l.style.lineWidth / LOW_ZOOM_WIDTH_DIVISOR) / 32) * (useSdf ? 1 : 0.5),
-              18,
-              ((l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER) / 24) * (useSdf ? 1 : 0.5),
-            ],
-            'icon-rotation-alignment': 'map',
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-            'icon-padding': 4,
-            'icon-offset': [
-              'case',
-              ['==', ['get', 'cycleway:right'], 'lane'],
-              [0, 44],
-              ['==', ['get', 'cycleway:left'], 'lane'],
-              [0, -44],
-              [0, 0],
-            ],
-          },
-          paint: {
-            'icon-occlusion-opacity': 1,
-            ...(useSdf && {
-              'icon-color': adjustColorBrightness(
-                l.style.lineColor,
-                this.props.isDarkMode ? 0.0 : -0.1,
-                'hsl'
-              ),
-              'icon-halo-width': 1,
-              'icon-halo-blur': 0,
-              'icon-halo-color': this.props.isDarkMode
-                ? MAP_COLORS.DARK.HALO
-                : MAP_COLORS.LIGHT.ICON_HALO,
-            }),
-            'icon-opacity': [
-              'case',
-              ['==', ['get', 'oneway:bicycle'], 'no'],
-              0,
-              ['==', ['get', 'oneway:bicycle'], 'yes'],
-              1,
-              ['==', ['get', 'oneway'], 'no'],
-              0,
-              ['==', ['get', 'oneway'], 'yes'],
-              1,
-              0,
-            ],
-          },
+    this.map.addLayer(
+      {
+        id: arrowLayerId,
+        type: 'symbol',
+        source: sourceId,
+        'source-layer': sourceLayer,
+        filter: filters,
+        minzoom: 12,
+        layout: {
+          'symbol-placement': 'line',
+          'symbol-spacing': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 20, 16, 80],
+          'icon-image': arrowIconName,
+          'icon-size': [
+            'interpolate',
+            ['exponential', 1.5],
+            ['zoom'],
+            10,
+            (Math.max(1, l.style.lineWidth / LOW_ZOOM_WIDTH_DIVISOR) / 32) * (useSdf ? 1 : 0.5),
+            18,
+            ((l.style.lineWidth * DEFAULT_LINE_WIDTH_MULTIPLIER) / 24) * (useSdf ? 1 : 0.5),
+          ],
+          'icon-rotation-alignment': 'map',
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true,
+          'icon-padding': 4,
+          'icon-offset': [
+            'case',
+            ['==', ['get', 'cycleway:right'], 'lane'],
+            [0, 44],
+            ['==', ['get', 'cycleway:left'], 'lane'],
+            [0, -44],
+            [0, 0],
+          ],
         },
-        layerUnderneathName
-      );
-    }
+        paint: {
+          'icon-occlusion-opacity': 1,
+          ...(useSdf && {
+            'icon-color': adjustColorBrightness(
+              l.style.lineColor,
+              this.props.isDarkMode ? 0.0 : -0.1,
+              'hsl'
+            ),
+            'icon-halo-width': 1,
+            'icon-halo-blur': 0,
+            'icon-halo-color': this.props.isDarkMode
+              ? MAP_COLORS.DARK.HALO
+              : MAP_COLORS.LIGHT.ICON_HALO,
+          }),
+          'icon-opacity': [
+            'case',
+            ['==', ['get', 'oneway:bicycle'], 'no'],
+            0,
+            ['==', ['get', 'oneway:bicycle'], 'yes'],
+            1,
+            ['==', ['get', 'oneway'], 'no'],
+            0,
+            ['==', ['get', 'oneway'], 'yes'],
+            1,
+            0,
+          ],
+        },
+      },
+      layerUnderneathName
+    );
 
     // Muted duplicate of the cycling layer shown only while routes are displayed.
     // Differences from the normal layer above:
@@ -1160,88 +1086,59 @@ class Map extends Component {
       layerUnderneathName
     );
 
-    // Only osmdata is interactive
-    if (sourceId === 'osmdata') {
-      this.map.on('click', interactiveLayerId, (e) => {
-        if (e.target.getZoom() < INTERACTIVE_LAYERS_ZOOM_THRESHOLD) {
+    this.map.on('click', interactiveLayerId, (e) => {
+      if (e.target.getZoom() < INTERACTIVE_LAYERS_ZOOM_THRESHOLD) {
+        return;
+      }
+      if (e && e.features && e.features.length > 0 && !e.originalEvent.defaultPrevented) {
+        // Disable cyclepath clicks when in route mode
+        if (self.props.isInRouteMode) {
+          e.originalEvent.preventDefault();
           return;
         }
-        if (e && e.features && e.features.length > 0 && !e.originalEvent.defaultPrevented) {
-          // Disable cyclepath clicks when in route mode
-          if (self.props.isInRouteMode) {
-            e.originalEvent.preventDefault();
-            return;
-          }
 
-          if (self.selectedCycleway) {
-            try {
-              self.map.setFeatureState(
-                { source: 'osmdata', id: self.selectedCycleway },
-                { selected: false, hover: false }
-              );
-            } catch (err) {}
-          }
-          self.selectedCycleway = e.features[0].id;
+        if (self.selectedCycleway) {
           try {
             self.map.setFeatureState(
-              { source: 'osmdata', id: self.selectedCycleway },
-              { selected: true }
+              { source: sourceId, sourceLayer: sourceLayer, id: self.selectedCycleway },
+              { selected: false, hover: false }
             );
           } catch (err) {}
-
-          const layer = self.props.layers.find(
-            (l) => l.id === e.features[0].layer.id.split('--')[0]
-          );
-          self.popups.showCyclewayPopup(e, layer);
-          if (IS_MOBILE && e.features && e.features[0]) {
-            const bb = turfBbox(e.features[0]); // [minX, minY, maxX, maxY]
-            const bounds = new mapboxgl.LngLatBounds([bb[0], bb[1]], [bb[2], bb[3]]);
-            self.map.fitBounds(bounds, {
-              padding: { top: 150, bottom: 300, left: 100, right: 100 },
-            });
-          }
-          e.originalEvent.preventDefault();
         }
-      });
-
-      // Since these structures are contiguous we need to use mousemove instead of mouseenter/mouseleave
-      this.map.on('mousemove', interactiveLayerId, (e) => {
-        if (e.features.length > 0) {
-          if (
-            e.target.getZoom() < INTERACTIVE_LAYERS_ZOOM_THRESHOLD ||
-            self.hoveredCycleway === e.features[0].id ||
-            self.props.isInRouteMode
-          ) {
-            return;
-          }
-
-          self.map.getCanvas().style.cursor = 'pointer';
-
-          if (self.hoveredCycleway) {
-            self.map.setFeatureState(
-              {
-                source: sourceId,
-                sourceLayer: sourceLayer,
-                id: self.hoveredCycleway,
-              },
-              { hover: false }
-            );
-          }
-
-          self.hoveredCycleway = e.features[0].id;
+        self.selectedCycleway = e.features[0].id;
+        try {
           self.map.setFeatureState(
-            {
-              source: sourceId,
-              sourceLayer: sourceLayer,
-              id: self.hoveredCycleway,
-            },
-            { hover: true }
+            { source: sourceId, sourceLayer: sourceLayer, id: self.selectedCycleway },
+            { selected: true }
           );
-        }
-      });
+        } catch (err) {}
 
-      this.map.on('mouseleave', interactiveLayerId, () => {
-        console.debug('mouseleave', interactiveLayerId);
+        const layer = self.props.layers.find((l) => l.id === e.features[0].layer.id.split('--')[0]);
+        self.popups.showCyclewayPopup(e, layer);
+        if (IS_MOBILE && e.features && e.features[0]) {
+          const bb = turfBbox(e.features[0]); // [minX, minY, maxX, maxY]
+          const bounds = new mapboxgl.LngLatBounds([bb[0], bb[1]], [bb[2], bb[3]]);
+          self.map.fitBounds(bounds, {
+            padding: { top: 150, bottom: 300, left: 100, right: 100 },
+          });
+        }
+        e.originalEvent.preventDefault();
+      }
+    });
+
+    // Since these structures are contiguous we need to use mousemove instead of mouseenter/mouseleave
+    this.map.on('mousemove', interactiveLayerId, (e) => {
+      if (e.features.length > 0) {
+        if (
+          e.target.getZoom() < INTERACTIVE_LAYERS_ZOOM_THRESHOLD ||
+          self.hoveredCycleway === e.features[0].id ||
+          self.props.isInRouteMode
+        ) {
+          return;
+        }
+
+        self.map.getCanvas().style.cursor = 'pointer';
+
         if (self.hoveredCycleway) {
           self.map.setFeatureState(
             {
@@ -1251,12 +1148,36 @@ class Map extends Component {
             },
             { hover: false }
           );
-
-          self.map.getCanvas().style.cursor = '';
         }
-        self.hoveredCycleway = null;
-      });
-    }
+
+        self.hoveredCycleway = e.features[0].id;
+        self.map.setFeatureState(
+          {
+            source: sourceId,
+            sourceLayer: sourceLayer,
+            id: self.hoveredCycleway,
+          },
+          { hover: true }
+        );
+      }
+    });
+
+    this.map.on('mouseleave', interactiveLayerId, () => {
+      console.debug('mouseleave', interactiveLayerId);
+      if (self.hoveredCycleway) {
+        self.map.setFeatureState(
+          {
+            source: sourceId,
+            sourceLayer: sourceLayer,
+            id: self.hoveredCycleway,
+          },
+          { hover: false }
+        );
+
+        self.map.getCanvas().style.cursor = '';
+      }
+      self.hoveredCycleway = null;
+    });
   }
 
   async initCommentsLayer() {
@@ -1400,17 +1321,6 @@ class Map extends Component {
   async initializeDataSources() {
     await this.awaitStyleReady();
 
-    if (!this.map.getSource('osmdata') && USE_GEOJSON_SOURCE) {
-      this.map.addSource('osmdata', {
-        type: 'geojson',
-        data: this.props.data || {
-          type: 'FeatureCollection',
-          features: [],
-        },
-        generateId: true,
-      });
-    }
-
     if (USE_PMTILES_SOURCE) {
       const pmtilesLoadToken = startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
       try {
@@ -1498,17 +1408,9 @@ class Map extends Component {
           if (this.pmtilesLoadedSuccessfully) {
             this.initCyclepathLayerForSource(l, 'pmtiles-source');
           }
-
-          if (USE_GEOJSON_SOURCE) {
-            this.initCyclepathLayerForSource(l, 'osmdata');
-          }
         } else if (l.type === 'poi' && l.filters) {
-          if (this.pmtilesLoadedSuccessfully && !USE_GEOJSON_SOURCE) {
+          if (this.pmtilesLoadedSuccessfully) {
             this.initPOILayerForSource(l, 'pmtiles-source');
-          }
-
-          if (USE_GEOJSON_SOURCE) {
-            this.initPOILayerForSource(l, 'osmdata');
           }
         }
       });
@@ -1862,14 +1764,8 @@ class Map extends Component {
     }
 
     if (this.props.data !== prevProps.data) {
-      if (map.getSource('osmdata')) {
-        map.getSource('osmdata').setData(this.props.data);
-      }
-
       // Reset stored filters when data changes
       this.originalRouteEndpointPoiFilters = null;
-
-      this.hideGeoJsonFromPmtiles(this.props.data);
 
       this.initBoundaryLayer();
     }
@@ -2444,11 +2340,10 @@ class Map extends Component {
       );
 
       routeEndpointPoiLayers.forEach((layer) => {
-        const originalFilter = this.convertFilterToMapboxFilter(layer, 'osmdata');
+        const originalFilter = this.convertFilterToMapboxFilter(layer);
         const endpointWithinFilter = ['all', originalFilter, spatialFilter];
 
-        // Only apply to GeoJSON source layers (not PMTiles)
-        const layerId = layer.id;
+        const layerId = layer.id + '--pmtiles';
         const circlesLayerId = layerId + 'circles';
         const polygonLayerId = layerId + 'polygon';
 
@@ -2467,7 +2362,6 @@ class Map extends Component {
         }
 
         // Apply within filter to all three layer types (circles, symbols, polygons)
-        // Only for GeoJSON source layers, skip PMTiles layers
         [circlesLayerId, layerId, polygonLayerId].forEach((id) => {
           if (map.getLayer(id)) {
             try {
@@ -2486,8 +2380,7 @@ class Map extends Component {
         );
 
         routeEndpointPoiLayers.forEach((layer) => {
-          // Only restore GeoJSON source layers (not PMTiles)
-          const layerId = layer.id;
+          const layerId = layer.id + '--pmtiles';
           const circlesLayerId = layerId + 'circles';
           const polygonLayerId = layerId + 'polygon';
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -449,7 +449,6 @@ class Map extends Component {
         filter: filters,
         description: l.description,
         type: 'circle',
-        minzoom: MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD,
         maxzoom: l.zoomThreshold,
         paint: {
           'circle-radius': ['interpolate', ['exponential', 1.5], ['zoom'], 12, 2, 15, 4],

--- a/src/Map.js
+++ b/src/Map.js
@@ -46,7 +46,6 @@ import { adjustColorBrightness } from './utils/utils.js';
 import debounce from 'lodash.debounce';
 import { getCurrentSunPosition } from './sunPositionUtils';
 import { arrowIconsByLayer, arrowIcons, arrowSdf, iconsMap } from './features/map/icons';
-import { reverseGeocodePlace } from './features/map/mapboxGeocoding.js';
 import { flyMapTo } from './features/map/mapCamera.js';
 import userLocationCache from './features/geolocation/userLocationCache.js';
 
@@ -116,8 +115,6 @@ class Map extends Component {
 
   airtableDatabase;
   comments;
-  debouncedMapStateSync;
-  lastGeocodedPlaceName;
   originalRouteEndpointPoiFilters; // POI layer filters before route-mode `within` is applied; restored when routes clear
   geolocateControl; // Reference to Mapbox GeolocateControl
   resizeObserver;
@@ -153,15 +150,6 @@ class Map extends Component {
     };
 
     this.layersInitialized = false;
-
-    // Create debounced map state sync function (only syncs if place name has been consistent for 1+ second).
-    // geocodeRequestTime is the timestamp of the reverseGeocode call that produced the placeName;
-    // it is forwarded to App.onMapMoved so that stale-geocode detection can compare against the
-    // navigation timestamp rather than the (later) resolution timestamp.
-    this.debouncedMapStateSync = debounce((placeName, geocodeRequestTime) => {
-      console.debug('Syncing map state with consistent place:', placeName);
-      this.syncMapState(placeName, geocodeRequestTime);
-    }, 1000);
   }
 
   _onSearchResultPopupClosed() {
@@ -200,72 +188,11 @@ class Map extends Component {
     this.initCommentsLayer();
   }
 
-  reverseGeocode(lngLat) {
-    return reverseGeocodePlace(lngLat).catch((err) => {
-      console.error('Reverse geocoding failed:', err);
-      throw err;
-    });
-  }
-
   onMapMoveEnded() {
     this.syncMapState();
-
-    // Mobile never shows a live city label from pan/zoom geocoding (top bar is a search
-    // placeholder; analytics sidebar is desktop-only). Skip Mapbox reverse-geocode entirely.
-    if (IS_MOBILE) {
-      return;
-    }
-
-    // Reverse geocoding here is only needed to keep the area/URL in sync while the
-    // analytics sidebar or routes panel is open (they depend on knowing the current
-    // area). Otherwise skip the Mapbox request entirely - it was firing on every pan.
-    if (!this.props.needsCityGeoJsonContext?.()) {
-      return;
-    }
-
-    if (this.map.getZoom() > MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD) {
-      const center = this.map.getCenter();
-      // Capture when this geocode request was initiated so App can distinguish stale
-      // (pre-navigation) results from fresh (post-navigation) ones.
-      const geocodeRequestTime = Date.now();
-      this.reverseGeocode([center.lng, center.lat])
-        .then((result) => {
-          const currentPlaceName = result.place_name;
-          // console.debug('Geocoding result:', currentPlaceName);
-
-          if (!this.lastGeocodedPlaceName) {
-            // Initial case
-            this.lastGeocodedPlaceName = this.props.location;
-            console.debug('Initializing last geocoded place name:', this.lastGeocodedPlaceName);
-          } else {
-            // Check if this is the same place as the last geocoding result
-            if (this.lastGeocodedPlaceName === currentPlaceName) {
-              // console.debug('Same place detected, not triggering debounced sync...');
-            } else {
-              console.debug(
-                'Different place detected (current: ' +
-                  currentPlaceName +
-                  ', last: ' +
-                  this.lastGeocodedPlaceName +
-                  '), cancelling previous sync and starting new timer'
-              );
-
-              // Different place - cancel previous debounced call and start new timer
-              this.debouncedMapStateSync.cancel();
-              this.lastGeocodedPlaceName = currentPlaceName;
-              this.debouncedMapStateSync(currentPlaceName, geocodeRequestTime);
-            }
-          }
-        })
-        .catch((err) => {
-          console.debug('Reverse geocoding failed:', err);
-        });
-    } else {
-      console.debug('Map zoom is below auto change area zoom threshold');
-    }
   }
 
-  syncMapState(newArea, geocodeRequestTime) {
+  syncMapState() {
     const center = this.map.getCenter();
     const ret = {
       lat: center.lat,
@@ -273,24 +200,13 @@ class Map extends Component {
       zoom: this.map.getZoom(),
     };
 
-    if (newArea) {
-      ret.area = newArea;
-      // Forward the request timestamp so App.onMapMoved can detect stale results.
-      if (geocodeRequestTime != null) {
-        ret._geocodeRequestTime = geocodeRequestTime;
-      }
-      // Area/city changes are rare and must flow through React state (city picker,
-      // data loading), so they go through the regular onMapMoved -> setState path.
-      this.props.onMapMoved(ret);
+    // Position-only sync (pan/zoom) is high-frequency. Route it through a
+    // dedicated callback that updates the URL WITHOUT triggering a React
+    // re-render of the heavy map subtree (see App.onMapPositionChange).
+    if (this.props.onMapPositionChange) {
+      this.props.onMapPositionChange(ret);
     } else {
-      // Position-only sync (pan/zoom) is high-frequency. Route it through a
-      // dedicated callback that updates the URL WITHOUT triggering a React
-      // re-render of the heavy map subtree (see App.onMapPositionChange).
-      if (this.props.onMapPositionChange) {
-        this.props.onMapPositionChange(ret);
-      } else {
-        this.props.onMapMoved(ret);
-      }
+      this.props.onMapMoved(ret);
     }
   }
 
@@ -573,19 +489,38 @@ class Map extends Component {
       return;
     }
 
-    let lineGeometry = boundary.geometry;
-    if (lineGeometry?.type === 'Polygon' && lineGeometry.coordinates?.[0]?.length) {
-      lineGeometry = { type: 'LineString', coordinates: lineGeometry.coordinates[0] };
-    } else if (lineGeometry?.type === 'MultiPolygon') {
-      const rings = lineGeometry.coordinates
-        .map((poly) => poly?.[0])
-        .filter((ring) => ring?.length);
-      if (rings.length === 1) {
-        lineGeometry = { type: 'LineString', coordinates: rings[0] };
-      } else if (rings.length > 1) {
-        lineGeometry = { type: 'MultiLineString', coordinates: rings };
-      }
+    // Outer ring(s) of the boundary polygon, reused below both for the dashed line and
+    // as holes cut into a world-covering mask. OSM boundary relations are assembled
+    // from ways and can come back broken (open ring, missing segment) when the
+    // Overpass query is incomplete — an invalid hole isn't rejected by the fill
+    // renderer, it's just skipped, which paints the mask across the *whole* map
+    // instead of just outside the city. Treat anything but a proper closed ring
+    // (4+ points, first === last) as "no boundary data" rather than risk that.
+    let rawRings = [];
+    if (boundary.geometry?.type === 'Polygon') {
+      rawRings = [boundary.geometry.coordinates?.[0]];
+    } else if (boundary.geometry?.type === 'MultiPolygon') {
+      rawRings = (boundary.geometry.coordinates || []).map((poly) => poly?.[0]);
     }
+    const outerRings = rawRings.filter((ring) => {
+      if (!Array.isArray(ring) || ring.length < 4) return false;
+      const first = ring[0];
+      const last = ring[ring.length - 1];
+      return (
+        Array.isArray(first) && Array.isArray(last) && first[0] === last[0] && first[1] === last[1]
+      );
+    });
+
+    if (outerRings.length === 0) {
+      if (this.map.getLayer('boundary-layer')) this.map.removeLayer('boundary-layer');
+      if (this.map.getSource('boundaryLineSrc')) this.map.removeSource('boundaryLineSrc');
+      return;
+    }
+
+    const lineGeometry =
+      outerRings.length === 1
+        ? { type: 'LineString', coordinates: outerRings[0] }
+        : { type: 'MultiLineString', coordinates: outerRings };
 
     const boundaryLineData = {
       type: 'FeatureCollection',
@@ -598,16 +533,58 @@ class Map extends Component {
       ],
     };
 
-    this.map.addSource('boundaryLineSrc', {
-      type: 'geojson',
-      data: boundaryLineData,
-    });
-
     const beforeRouteLayer = this.map.getLayer('route-padding-selected')
       ? 'route-padding-selected'
       : this.map.getLayer('route-paddings-unselected')
         ? 'route-paddings-unselected'
         : undefined;
+
+    // Dark mask: a world-covering polygon with the city boundary punched out as a
+    // hole, so everything outside the city reads as dimmed rather than highlighted.
+    const maskData = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-180, -90],
+                [180, -90],
+                [180, 90],
+                [-180, 90],
+                [-180, -90],
+              ],
+              ...outerRings,
+            ],
+          },
+        },
+      ],
+    };
+
+    this.map.addSource('boundaryMaskSrc', {
+      type: 'geojson',
+      data: maskData,
+    });
+
+    this.map.addLayer(
+      {
+        id: 'boundary-mask',
+        type: 'fill',
+        source: 'boundaryMaskSrc',
+        paint: {
+          'fill-color': '#000000',
+          'fill-opacity': ['interpolate', ['linear'], ['zoom'], 9, 0, 12, isDarkMode ? 0.45 : 0.25],
+        },
+      },
+      beforeRouteLayer
+    );
+
+    this.map.addSource('boundaryLineSrc', {
+      type: 'geojson',
+      data: boundaryLineData,
+    });
 
     this.map.addLayer(
       {
@@ -1783,6 +1760,17 @@ class Map extends Component {
           this.props.isDarkMode ? MAP_COLORS.DARK.BOUNDARY : MAP_COLORS.LIGHT.BOUNDARY
         );
       }
+      if (map.getLayer('boundary-mask')) {
+        map.setPaintProperty('boundary-mask', 'fill-opacity', [
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          9,
+          0,
+          12,
+          this.props.isDarkMode ? 0.45 : 0.25,
+        ]);
+      }
     }
 
     const layersChanged = this.props.layers.some((layer, index) => {
@@ -2673,24 +2661,7 @@ class Map extends Component {
     // Initialize map after style is loaded
     this.initializeMapAfterStyleLoad();
 
-    // Initialize map center. Match onMapMoveEnded: mobile never reverse-geocodes
-    // (no live city label), so skip the Mapbox request on startup too. Also skip
-    // when we already know the area (city picker/route) - no need to re-derive it.
-    const shouldInitializeArea =
-      !IS_MOBILE && !this.props.location && this.props.zoom >= MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD;
-    if (shouldInitializeArea) {
-      this.reverseGeocode([this.props.lng, this.props.lat])
-        .then((result) => {
-          this.syncMapState(result.place_name);
-        })
-        .catch((err) => {
-          // Reverse geocoding failure is not critical - map can function without it
-          console.debug('Reverse geocoding failed during initialization:', err.message);
-        });
-    } else {
-      // Preserve map state without forcing an area when zoomed out (or on mobile).
-      this.syncMapState();
-    }
+    this.syncMapState();
   }
 
   initMapControls() {
@@ -3043,9 +3014,6 @@ class Map extends Component {
     // Cancel any pending debounced calls
     if (this.debouncedOnMapMoveEnded) {
       this.debouncedOnMapMoveEnded.cancel();
-    }
-    if (this.debouncedMapStateSync) {
-      this.debouncedMapStateSync.cancel();
     }
 
     if (this.map) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -550,9 +550,7 @@ class Map extends Component {
     }
 
     const isDarkMode = this.props.isDarkMode;
-    const boundaryLineColor = isDarkMode
-      ? MAP_COLORS.DARK.ROUTE_BORDER
-      : MAP_COLORS.LIGHT.ROUTE_BORDER;
+    const boundaryLineColor = isDarkMode ? MAP_COLORS.DARK.BOUNDARY : MAP_COLORS.LIGHT.BOUNDARY;
 
     const boundaryFeatures = (this.props.data?.features || []).filter(
       (f) => f.properties?.boundary === 'administrative'
@@ -600,64 +598,35 @@ class Map extends Component {
       ],
     };
 
-    if (!this.map.getSource('boundaryLineSrc')) {
-      this.map.addSource('boundaryLineSrc', {
-        type: 'geojson',
-        data: boundaryLineData,
-      });
-    } else {
-      this.map.getSource('boundaryLineSrc').setData(boundaryLineData);
-    }
+    this.map.addSource('boundaryLineSrc', {
+      type: 'geojson',
+      data: boundaryLineData,
+    });
 
-    if (!this.map.getLayer('boundary-layer')) {
-      const beforeRouteLayer = this.map.getLayer('route-padding-selected')
-        ? 'route-padding-selected'
-        : this.map.getLayer('route-paddings-unselected')
-          ? 'route-paddings-unselected'
-          : undefined;
+    const beforeRouteLayer = this.map.getLayer('route-padding-selected')
+      ? 'route-padding-selected'
+      : this.map.getLayer('route-paddings-unselected')
+        ? 'route-paddings-unselected'
+        : undefined;
 
-      this.map.addLayer(
-        {
-          id: 'boundary-layer',
-          type: 'line',
-          source: 'boundaryLineSrc',
-          layout: {
-            'line-join': 'round',
-            'line-cap': 'round',
-          },
-          paint: {
-            'line-color': boundaryLineColor,
-            'line-width': ['interpolate', ['linear'], ['zoom'], 10, 1, 14, 1.5],
-            'line-opacity': ['interpolate', ['linear'], ['zoom'], 9, 0, 15, 0.8],
-            'line-dasharray': [1.5, 2.5],
-          },
+    this.map.addLayer(
+      {
+        id: 'boundary-layer',
+        type: 'line',
+        source: 'boundaryLineSrc',
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
         },
-        beforeRouteLayer
-      );
-    } else {
-      this.map.setPaintProperty('boundary-layer', 'line-color', boundaryLineColor);
-      this.map.setPaintProperty('boundary-layer', 'line-width', [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        10,
-        1,
-        14,
-        1.5,
-      ]);
-      this.map.setPaintProperty('boundary-layer', 'line-opacity', [
-        'interpolate',
-        ['linear'],
-        ['zoom'],
-        9,
-        0,
-        11,
-        0.2,
-        14,
-        0.35,
-      ]);
-      this.map.setPaintProperty('boundary-layer', 'line-dasharray', [1.5, 2.5]);
-    }
+        paint: {
+          'line-color': boundaryLineColor,
+          'line-width': ['interpolate', ['linear'], ['zoom'], 10, 2, 14, 1],
+          'line-opacity': ['interpolate', ['linear'], ['zoom'], 9, 0.5, 15, 1],
+          'line-dasharray': [1.5, 2.5],
+        },
+      },
+      beforeRouteLayer
+    );
   }
 
   // Boundary mask (disabled) — dims everything outside the city polygon.
@@ -1811,7 +1780,7 @@ class Map extends Component {
         map.setPaintProperty(
           'boundary-layer',
           'line-color',
-          this.props.isDarkMode ? MAP_COLORS.DARK.ROUTE_BORDER : MAP_COLORS.LIGHT.ROUTE_BORDER
+          this.props.isDarkMode ? MAP_COLORS.DARK.BOUNDARY : MAP_COLORS.LIGHT.BOUNDARY
         );
       }
     }

--- a/src/Map.js
+++ b/src/Map.js
@@ -1137,7 +1137,15 @@ class Map extends Component {
       this.map.removeLayer('comentarios');
     }
 
-    this.setState(await this.airtableDatabase.getComments(), () => {
+    let commentsData;
+    try {
+      commentsData = await this.airtableDatabase.getComments();
+    } catch (err) {
+      console.warn('Failed to load comments', err);
+      return;
+    }
+
+    this.setState(commentsData, () => {
       if (this.state.comments.length > 0) {
         this.map.getSource('commentsSrc').setData({
           type: 'FeatureCollection',

--- a/src/Map.js
+++ b/src/Map.js
@@ -2780,6 +2780,10 @@ class Map extends Component {
       this.map.addControl(geolocate, 'bottom-right');
       const geolocateButton = geolocate._container?.querySelector('button');
       if (geolocateButton) geolocateButton.setAttribute('aria-label', 'Mostrar minha localização');
+      // Desktop: control stays mounted for trigger(), but the visible button lives in the topbar.
+      if (!IS_MOBILE && geolocate._container) {
+        geolocate._container.classList.add('mapboxgl-ctrl-geolocate-host--topbar');
+      }
 
       // Restore tracking state if it was active before
       // Note: trigger() will start tracking if trackUserLocation is true
@@ -2812,6 +2816,12 @@ class Map extends Component {
       // this.map.addControl(new mapboxgl.FullscreenControl({
       //     container: document.querySelector('body')
       // }), 'bottom-right');
+    }
+  }
+
+  triggerGeolocate() {
+    if (this.geolocateControl && typeof this.geolocateControl.trigger === 'function') {
+      this.geolocateControl.trigger();
     }
   }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -1323,7 +1323,7 @@ class Map extends Component {
 
     if (USE_PMTILES_SOURCE) {
       const PMTILES_URL = process.env.REACT_APP_PMTILES_URL + PMTILES_FILENAME;
-      startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
+      const pmtilesLoadToken = startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
 
       try {
         console.log('Loading PMTiles (native vector source):', PMTILES_URL);
@@ -1344,14 +1344,21 @@ class Map extends Component {
           if (e.sourceId === 'pmtiles-source' && e.isSourceLoaded) {
             this.map.off('sourcedata', onSourceData);
             this.map.off('error', onPmtilesError);
-            finishDataLoad('pmtiles', { meta: { file: PMTILES_FILENAME } });
+            finishDataLoad('pmtiles', {
+              token: pmtilesLoadToken,
+              meta: { file: PMTILES_FILENAME },
+            });
           }
         };
         const onPmtilesError = (e) => {
           if (e.sourceId === 'pmtiles-source') {
             this.map.off('sourcedata', onSourceData);
             this.map.off('error', onPmtilesError);
-            finishDataLoad('pmtiles', { error: e.error, meta: { file: PMTILES_FILENAME } });
+            finishDataLoad('pmtiles', {
+              token: pmtilesLoadToken,
+              error: e.error,
+              meta: { file: PMTILES_FILENAME },
+            });
           }
         };
         this.map.on('sourcedata', onSourceData);
@@ -1359,7 +1366,11 @@ class Map extends Component {
       } catch (error) {
         console.error('Error setting up PMTiles source:', error);
         this.pmtilesLoadedSuccessfully = false;
-        finishDataLoad('pmtiles', { error, meta: { file: PMTILES_FILENAME } });
+        finishDataLoad('pmtiles', {
+          token: pmtilesLoadToken,
+          error,
+          meta: { file: PMTILES_FILENAME },
+        });
       }
     }
   }

--- a/src/MapPopups.js
+++ b/src/MapPopups.js
@@ -219,11 +219,10 @@ class MapPopups {
       if (this.selectedCycleway) {
         try {
           this.map.setFeatureState(
-            { source: 'osmdata', id: this.selectedCycleway },
+            { source: 'pmtiles-source', sourceLayer: 'default', id: this.selectedCycleway },
             { selected: false, hover: false }
           );
         } catch (e) {}
-        // try { this.map.setFeatureState({ source: 'pmtiles-source', id: this.selectedCycleway }, { selected: false, hover: false }); } catch (e) {}
       }
       this.selectedCycleway = null;
     });

--- a/src/TopBar.css
+++ b/src/TopBar.css
@@ -38,6 +38,14 @@
 }
 
 
+/* Desktop: empty search-field affordance (same copy/treatment as mobile) */
+.city-picker__search--desktop.ant-btn {
+  min-width: 280px;
+  justify-content: flex-start;
+  text-align: left;
+  font-weight: 400;
+}
+
 /* Desktop topbar map actions: shared size (solid fills read heavier than the glass
    search field, so a hair smaller for optical balance). Colors stay per-button. */
 .topbar-map-action.ant-btn {

--- a/src/TopBar.css
+++ b/src/TopBar.css
@@ -37,7 +37,6 @@
   }
 }
 
-
 /* Desktop: empty search-field affordance (same copy/treatment as mobile) */
 .city-picker__search--desktop.ant-btn {
   min-width: 280px;
@@ -89,6 +88,48 @@ body.theme-light
   background: #374151;
   border: 1px solid rgba(0, 0, 0, 0.35);
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+/* Very small desktop: collapse theme + Sobre / Colaborar / Métricas into an overflow menu.
+   Nav is already hidden below Tailwind `sm` (640px); mobile chrome is ≤480px.
+   Avoid Tailwind `flex` on these nodes — utilities load after TopBar.css and would
+   beat a plain `display: none`. */
+.topbar-nav-expanded {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 1100px) {
+  .topbar-nav-expanded {
+    display: none;
+  }
+}
+
+@media (min-width: 1101px) {
+  .topbar-nav-overflow {
+    display: none;
+  }
+}
+
+/* Overflow menu: keep icon + label vertically centered (submenu title has an expand
+   chevron that otherwise throws off HiUsers vs the label). */
+.topbar-nav-overflow-dropdown .ant-dropdown-menu-item,
+.topbar-nav-overflow-dropdown .ant-dropdown-menu-submenu-title {
+  display: flex;
+  align-items: center;
+}
+
+.topbar-nav-overflow-dropdown .ant-dropdown-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.topbar-nav-overflow-dropdown .ant-dropdown-menu-item-icon .react-icon {
+  margin-right: 0;
+  display: block;
 }
 
 /* Mobile */

--- a/src/TopBar.css
+++ b/src/TopBar.css
@@ -37,6 +37,52 @@
   }
 }
 
+
+/* Desktop topbar map actions: shared size (solid fills read heavier than the glass
+   search field, so a hair smaller for optical balance). Colors stay per-button. */
+.topbar-map-action.ant-btn {
+  --topbar-map-action-size: calc(var(--ant-control-height, 32px) - 2px);
+  width: var(--topbar-map-action-size);
+  height: var(--topbar-map-action-size);
+  min-width: var(--topbar-map-action-size);
+  padding: 0;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05em;
+}
+
+/* Route: solid primary */
+#directionsPanelTopbarButton.topbar-map-action.ant-btn {
+  color: #283e2a;
+  background: #f3f4f6;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+body.theme-light #directionsPanelTopbarButton.topbar-map-action.ant-btn {
+  color: #f9fafb;
+  background: #283e2a;
+  border-color: transparent;
+}
+
+#ciclomapa:has(#directionsPanel.directions-panel-open)
+  #directionsPanelTopbarButton.topbar-map-action.ant-btn {
+  color: #283e2a;
+  background: #d1d5db;
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+body.theme-light
+  #ciclomapa:has(#directionsPanel.directions-panel-open)
+  #directionsPanelTopbarButton.topbar-map-action.ant-btn {
+  color: #f9fafb;
+  background: #374151;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+
 /* Mobile */
 
 @media (min-width: 320px) and (max-width: 480px) {

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { Space, Button, Popover, Dropdown } from 'antd';
+import { Space, Button, Popover, Dropdown, Tooltip } from 'antd';
 
 import {
   HiOutlineMap as IconMap,
@@ -15,6 +15,8 @@ import {
 } from 'react-icons/hi';
 
 import { IconContext } from 'react-icons';
+import { LuBike } from 'react-icons/lu';
+import { MdMyLocation } from 'react-icons/md';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -47,6 +49,8 @@ function TopBar(props) {
     openAboutModal,
     isSidebarOpen,
     toggleSidebar,
+    toggleDirectionsPanel,
+    triggerGeolocate,
   } = props;
 
   const navigate = useNavigate();
@@ -169,36 +173,70 @@ function TopBar(props) {
               onMouseLeave={() => !IS_MOBILE && setIsCityPickerHovered(false)}
             >
               <div className="flex flex-col items-center sm:mb-1">
-                <div className={`relative z-10 ${IS_MOBILE && 'w-full'} rounded-full`}>
-                  <Button
-                    className="glass-bg"
-                    block={IS_MOBILE}
-                    size={IS_MOBILE ? 'large' : 'middle'}
-                    onClick={showCityPicker}
-                    aria-label={
-                      IS_MOBILE
-                        ? `Buscar cidade ou endereço. Cidade atual: ${city}, ${state}`
-                        : undefined
-                    }
-                  >
-                    <h2 className="flex items-center gap-1 m-0 sm:w-auto w-full min-w-0">
-                      <IconSearch className="opacity-60 flex-shrink-0 -ml-1" aria-hidden />
+                <div
+                  className={`relative z-10 flex items-center gap-2 ${IS_MOBILE ? 'w-full' : ''}`}
+                >
+                  <div className={`relative ${IS_MOBILE ? 'w-full' : ''} rounded-full`}>
+                    <Button
+                      className="glass-bg"
+                      block={IS_MOBILE}
+                      size={IS_MOBILE ? 'large' : 'middle'}
+                      onClick={showCityPicker}
+                      aria-label={
+                        IS_MOBILE
+                          ? `Buscar cidade ou endereço. Cidade atual: ${city}, ${state}`
+                          : undefined
+                      }
+                    >
+                      <h2 className="flex items-center gap-1 m-0 sm:w-auto w-full min-w-0">
+                        <IconSearch className="opacity-60 flex-shrink-0 -ml-1" aria-hidden />
 
-                      {IS_MOBILE ? (
-                        <span className="opacity-60 truncate">Buscar cidade ou endereço</span>
-                      ) : (
-                        <span>
-                          {city}, {state}
-                        </span>
-                      )}
-                    </h2>
-                  </Button>
-                  {loading && (
-                    <div className="loader-container h-1 absolute bottom-0 left-0 right-0">
-                      <div className="progress-materializecss">
-                        <div className="indeterminate"></div>
+                        {IS_MOBILE ? (
+                          <span className="opacity-60 truncate">Buscar cidade ou endereço</span>
+                        ) : (
+                          <span>
+                            {city}, {state}
+                          </span>
+                        )}
+                      </h2>
+                    </Button>
+                    {loading && (
+                      <div className="loader-container h-1 absolute bottom-0 left-0 right-0">
+                        <div className="progress-materializecss">
+                          <div className="indeterminate"></div>
+                        </div>
                       </div>
-                    </div>
+                    )}
+                  </div>
+
+                  {!IS_MOBILE && triggerGeolocate && (
+                    <Tooltip title="Mostrar minha localização" placement="bottom">
+                      <Button
+                        id="geolocateTopbarButton"
+                        className="glass-bg topbar-map-action"
+                        size="middle"
+                        shape="circle"
+                        onClick={triggerGeolocate}
+                        aria-label="Mostrar minha localização"
+                      >
+                        <MdMyLocation aria-hidden />
+                      </Button>
+                    </Tooltip>
+                  )}
+
+                  {!IS_MOBILE && toggleDirectionsPanel && (
+                    <Tooltip title="Planejar rota de bicicleta" placement="bottom">
+                      <Button
+                        id="directionsPanelTopbarButton"
+                        className="topbar-map-action directions-topbar-button"
+                        size="middle"
+                        shape="circle"
+                        onClick={toggleDirectionsPanel}
+                        aria-label="Planejar rota de bicicleta"
+                      >
+                        <LuBike aria-hidden />
+                      </Button>
+                    </Tooltip>
                   )}
                 </div>
 
@@ -350,6 +388,8 @@ TopBar.propTypes = {
   openAboutModal: PropTypes.func.isRequired,
   isSidebarOpen: PropTypes.bool,
   toggleSidebar: PropTypes.func.isRequired,
+  toggleDirectionsPanel: PropTypes.func,
+  triggerGeolocate: PropTypes.func,
 };
 
 TopBar.defaultProps = {

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -1,11 +1,10 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
-import { Space, Button, Popover, Dropdown, Tooltip } from 'antd';
+import { Space, Button, Dropdown, Tooltip } from 'antd';
 
 import {
   HiOutlineMap as IconMap,
-  HiOutlineRefresh as IconUpdate,
   HiOutlineChevronDown as IconCaret,
   HiPencil as IconEdit,
   HiChatAlt as IconComment,
@@ -24,7 +23,7 @@ import { MdMyLocation } from 'react-icons/md';
 
 import { useNavigate } from 'react-router-dom';
 
-import { timeSince, getOsmUrl } from './utils/utils.js';
+import { getOsmUrl } from './utils/utils.js';
 
 import { TOPBAR_HEIGHT, IS_MOBILE, IS_PROD, ENABLE_COMMENTS } from './config/constants.js';
 
@@ -33,19 +32,13 @@ import Logo from './components/Logo';
 
 import './TopBar.css';
 
-const LAST_UPDATE_LABEL_VISIBLE_MS = 6000;
-
 function TopBar(props) {
   const {
     title,
-    lastUpdate,
-    forceUpdate,
     embedMode,
     debugMode,
     isDarkMode,
     toggleTheme,
-    loading,
-    cancelDataLoad,
     lat,
     lng,
     z,
@@ -68,18 +61,6 @@ function TopBar(props) {
 
   const [editModal, setEditModal] = useState(false);
   const [hasDismissedEditModal, setHasDismissedEditModal] = useState(false);
-  const [showLastUpdate, setShowLastUpdate] = useState(false);
-  const [isCityPickerHovered, setIsCityPickerHovered] = useState(false);
-
-  useEffect(() => {
-    if (loading || !lastUpdate) {
-      setShowLastUpdate(false);
-      return undefined;
-    }
-    setShowLastUpdate(true);
-    const timer = setTimeout(() => setShowLastUpdate(false), LAST_UPDATE_LABEL_VISIBLE_MS);
-    return () => clearTimeout(timer);
-  }, [title, lastUpdate, loading]);
 
   const openEditModal = useCallback(() => setEditModal(true), []);
   const closeEditModal = useCallback(() => setEditModal(false), []);
@@ -126,15 +107,9 @@ function TopBar(props) {
     ]
   );
 
-  const showLastUpdateLabel = showLastUpdate || (!IS_MOBILE && isCityPickerHovered);
-
   const parts = title.split(',');
   const city = parts[0];
   const state = parts[1];
-  let updatedAtStr;
-  if (lastUpdate) {
-    updatedAtStr = lastUpdate.toLocaleString('pt-BR');
-  }
 
   const collaborateMenu = {
     items: [
@@ -217,11 +192,7 @@ function TopBar(props) {
           )}
 
           {!embedMode && (
-            <div
-              className={`city-picker sm:text-center ${IS_MOBILE ? 'w-full' : ''}`}
-              onMouseEnter={() => !IS_MOBILE && setIsCityPickerHovered(true)}
-              onMouseLeave={() => !IS_MOBILE && setIsCityPickerHovered(false)}
-            >
+            <div className={`city-picker sm:text-center ${IS_MOBILE ? 'w-full' : ''}`}>
               <div className="flex flex-col items-center sm:mb-1">
                 <div
                   className={`relative z-10 flex items-center gap-2 ${IS_MOBILE ? 'w-full' : ''}`}
@@ -239,13 +210,6 @@ function TopBar(props) {
                         <span className="opacity-60 truncate">Buscar</span>
                       </span>
                     </Button>
-                    {loading && (
-                      <div className="loader-container h-1 absolute bottom-0 left-0 right-0">
-                        <div className="progress-materializecss">
-                          <div className="indeterminate"></div>
-                        </div>
-                      </div>
-                    )}
                   </div>
 
                   {!IS_MOBILE && triggerGeolocate && (
@@ -278,64 +242,6 @@ function TopBar(props) {
                     </Tooltip>
                   )}
                 </div>
-
-                {!IS_MOBILE &&
-                  (!loading ? (
-                    lastUpdate && (
-                      <Popover
-                        trigger={IS_MOBILE ? 'click' : 'hover'}
-                        placement="bottom"
-                        arrow={{ pointAtCenter: true }}
-                        content={
-                          <div style={{ maxWidth: 250 }}>
-                            <Space size="small" orientation="vertical">
-                              {lastUpdate && (
-                                <div>
-                                  O mapa de {city} que você está vendo é uma cópia dos dados obtidos
-                                  do OpenStreetMap há <b>{timeSince(lastUpdate)}</b> ({updatedAtStr}
-                                  ).
-                                </div>
-                              )}
-
-                              <Button
-                                size="small"
-                                icon={<IconUpdate />}
-                                type="primary"
-                                block
-                                onClick={forceUpdate}
-                              >
-                                Atualizar
-                              </Button>
-                            </Space>
-                          </div>
-                        }
-                      >
-                        <div
-                          className={[
-                            'flex flex-center items-center gap-1 font-regular cursor text-xs transition-all transform  duration-700 ease-out',
-                            showLastUpdateLabel
-                              ? 'opacity-50 translate-y-1.5 hover:opacity-100'
-                              : ' opacity-0 -translate-y-3 pointer-events-none',
-                          ].join(' ')}
-                          aria-hidden={!showLastUpdateLabel}
-                        >
-                          Atualizado há {timeSince(lastUpdate)}
-                        </div>
-                      </Popover>
-                    )
-                  ) : (
-                    <div className="flex flex-center items-center gap-1 font-regular text-xs mt-1 opacity-50 hover:opacity-100 transition-opacity duration-300">
-                      Acessando dados do OpenStreetMap...
-                      <Button
-                        type="link"
-                        size="small"
-                        className="text-xs p-0 h-auto min-h-0 text-inherit opacity-70 hover:opacity-100"
-                        onClick={cancelDataLoad}
-                      >
-                        Cancelar
-                      </Button>
-                    </div>
-                  ))}
               </div>
             </div>
           )}
@@ -435,14 +341,10 @@ export default TopBar;
 
 TopBar.propTypes = {
   title: PropTypes.string.isRequired,
-  lastUpdate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
-  forceUpdate: PropTypes.func.isRequired,
   embedMode: PropTypes.bool,
   debugMode: PropTypes.bool,
   isDarkMode: PropTypes.bool,
   toggleTheme: PropTypes.func.isRequired,
-  loading: PropTypes.bool,
-  cancelDataLoad: PropTypes.func,
   lat: PropTypes.number,
   lng: PropTypes.number,
   z: PropTypes.number,
@@ -455,12 +357,9 @@ TopBar.propTypes = {
 };
 
 TopBar.defaultProps = {
-  lastUpdate: null,
   embedMode: false,
   debugMode: false,
   isDarkMode: false,
-  loading: false,
-  cancelDataLoad: () => {},
   lat: null,
   lng: null,
   z: null,

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -161,14 +161,14 @@ function TopBar(props) {
       >
         <div className="flex items-start justify-between text-white w-full">
           {!IS_MOBILE && (
-            <a href="/" className={'mt-2'}>
+            <a href="/" className="mt-2">
               <Logo className={embedMode ? 'text-white opacity-20' : 'text-sm'} />
             </a>
           )}
 
           {!embedMode && (
             <div
-              className={`city-picker sm:text-center ${IS_MOBILE && 'w-full'}`}
+              className={`city-picker sm:text-center ${IS_MOBILE ? 'w-full' : ''}`}
               onMouseEnter={() => !IS_MOBILE && setIsCityPickerHovered(true)}
               onMouseLeave={() => !IS_MOBILE && setIsCityPickerHovered(false)}
             >
@@ -178,27 +178,16 @@ function TopBar(props) {
                 >
                   <div className={`relative ${IS_MOBILE ? 'w-full' : ''} rounded-full`}>
                     <Button
-                      className="glass-bg"
+                      className={`glass-bg city-picker__search ${IS_MOBILE ? '' : 'city-picker__search--desktop'}`}
                       block={IS_MOBILE}
                       size={IS_MOBILE ? 'large' : 'middle'}
                       onClick={showCityPicker}
-                      aria-label={
-                        IS_MOBILE
-                          ? `Buscar cidade ou endereço. Cidade atual: ${city}, ${state}`
-                          : undefined
-                      }
+                      aria-label={`Buscar. Cidade atual: ${city}, ${state}`}
                     >
-                      <h2 className="flex items-center gap-1 m-0 sm:w-auto w-full min-w-0">
+                      <span className="flex items-center gap-1 m-0 sm:w-auto w-full min-w-0 font-normal">
                         <IconSearch className="opacity-60 flex-shrink-0 -ml-1" aria-hidden />
-
-                        {IS_MOBILE ? (
-                          <span className="opacity-60 truncate">Buscar cidade ou endereço</span>
-                        ) : (
-                          <span>
-                            {city}, {state}
-                          </span>
-                        )}
-                      </h2>
+                        <span className="opacity-60 truncate">Buscar</span>
+                      </span>
                     </Button>
                     {loading && (
                       <div className="loader-container h-1 absolute bottom-0 left-0 right-0">

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -175,13 +175,22 @@ function TopBar(props) {
                     block={IS_MOBILE}
                     size={IS_MOBILE ? 'large' : 'middle'}
                     onClick={showCityPicker}
+                    aria-label={
+                      IS_MOBILE
+                        ? `Buscar cidade ou endereço. Cidade atual: ${city}, ${state}`
+                        : undefined
+                    }
                   >
                     <h2 className="flex items-center gap-1 m-0 sm:w-auto w-full min-w-0">
                       <IconSearch className="opacity-60 flex-shrink-0 -ml-1" aria-hidden />
 
-                      <span>
-                        {city}, {state}
-                      </span>
+                      {IS_MOBILE ? (
+                        <span className="opacity-60 truncate">Buscar cidade ou endereço</span>
+                      ) : (
+                        <span>
+                          {city}, {state}
+                        </span>
+                      )}
                     </h2>
                   </Button>
                   {loading && (

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -12,6 +12,10 @@ import {
   HiSun as IconSun,
   HiMoon as IconMoon,
   HiSearch as IconSearch,
+  HiInformationCircle as IconAbout,
+  HiUsers as IconCollaborate,
+  HiChartPie as IconMetrics,
+  HiDotsVertical as IconMore,
 } from 'react-icons/hi';
 
 import { IconContext } from 'react-icons';
@@ -150,6 +154,52 @@ function TopBar(props) {
       },
     ],
     onClick: handleMenuClick,
+  };
+
+  const overflowMenu = {
+    items: [
+      ...(!isSidebarOpen
+        ? [
+            {
+              key: 'metrics',
+              icon: <IconMetrics />,
+              label: 'Métricas',
+            },
+          ]
+        : []),
+      {
+        key: 'collaborate',
+        icon: <IconCollaborate />,
+        label: 'Colaborar',
+        children: collaborateMenu.items,
+      },
+      ...(!IS_PROD && debugMode
+        ? [
+            {
+              key: 'review-icons',
+              label: 'Revisar ícones',
+            },
+          ]
+        : []),
+      {
+        key: 'about',
+        icon: <IconAbout />,
+        label: 'Sobre',
+      },
+      { type: 'divider' },
+      {
+        key: 'theme',
+        icon: isDarkMode ? <IconSun /> : <IconMoon />,
+        label: isDarkMode ? 'Tema claro' : 'Tema escuro',
+      },
+    ],
+    onClick: ({ key }) => {
+      if (key === 'theme') toggleTheme();
+      else if (key === 'about') openAboutModal();
+      else if (key === 'review-icons') navigate('/dev/place-type-icons');
+      else if (key === 'metrics') toggleSidebar(true);
+      else handleMenuClick({ key });
+    },
   };
 
   return (
@@ -293,49 +343,72 @@ function TopBar(props) {
           <div className="nav-links font-white">
             {!embedMode ? (
               <div className="hidden sm:flex gap-2 items-center">
-                <Space.Compact className="glass-bg rounded-full overflow-hidden">
-                  <Button
-                    type={!isDarkMode ? 'default' : 'text'}
-                    className={!isDarkMode ? 'border border-opacity-10 border-white' : 'opacity-50'}
-                    shape="circle"
-                    onClick={() => toggleTheme()}
-                    aria-label="Usar tema claro"
-                  >
-                    <IconSun />
-                  </Button>
-                  <Button
-                    type={isDarkMode ? 'default' : 'text'}
-                    className={isDarkMode ? 'border border-opacity-10 border-white' : 'opacity-50'}
-                    shape="circle"
-                    onClick={() => toggleTheme()}
-                    aria-label="Usar tema escuro"
-                  >
-                    <IconMoon />
-                  </Button>
-                </Space.Compact>
+                <div className="topbar-nav-expanded">
+                  <Space.Compact className="glass-bg rounded-full overflow-hidden">
+                    <Button
+                      type={!isDarkMode ? 'default' : 'text'}
+                      className={
+                        !isDarkMode ? 'border border-opacity-10 border-white' : 'opacity-50'
+                      }
+                      shape="circle"
+                      onClick={() => toggleTheme()}
+                      aria-label="Usar tema claro"
+                    >
+                      <IconSun />
+                    </Button>
+                    <Button
+                      type={isDarkMode ? 'default' : 'text'}
+                      className={
+                        isDarkMode ? 'border border-opacity-10 border-white' : 'opacity-50'
+                      }
+                      shape="circle"
+                      onClick={() => toggleTheme()}
+                      aria-label="Usar tema escuro"
+                    >
+                      <IconMoon />
+                    </Button>
+                  </Space.Compact>
 
-                <Button className="glass-bg" onClick={openAboutModal}>
-                  Sobre
-                </Button>
-
-                {!IS_PROD && debugMode && (
-                  <Button className="glass-bg" onClick={() => navigate('/dev/place-type-icons')}>
-                    Revisar ícones
+                  <Button className="glass-bg" onClick={openAboutModal}>
+                    Sobre
                   </Button>
-                )}
 
-                <Dropdown menu={collaborateMenu}>
-                  <Button className="glass-bg">
-                    <span> Colaborar </span>
-                    <IconCaret className="text-green-300" style={{ marginRight: '-3px' }} />
-                  </Button>
+                  {!IS_PROD && debugMode && (
+                    <Button className="glass-bg" onClick={() => navigate('/dev/place-type-icons')}>
+                      Revisar ícones
+                    </Button>
+                  )}
+
+                  <Dropdown menu={collaborateMenu}>
+                    <Button className="glass-bg">
+                      <span> Colaborar </span>
+                      <IconCaret className="text-green-300" style={{ marginRight: '-3px' }} />
+                    </Button>
+                  </Dropdown>
+
+                  {!isSidebarOpen && (
+                    <Button className="glass-bg" onClick={() => toggleSidebar(true)}>
+                      Métricas
+                    </Button>
+                  )}
+                </div>
+
+                <Dropdown
+                  menu={{ ...overflowMenu, className: 'topbar-nav-overflow-menu' }}
+                  trigger={['click']}
+                  placement="bottomRight"
+                  classNames={{ root: 'topbar-nav-overflow-dropdown' }}
+                >
+                  <Tooltip title="Mais opções">
+                    <Button
+                      className="glass-bg topbar-nav-overflow"
+                      shape="circle"
+                      aria-label="Mais opções"
+                    >
+                      <IconMore aria-hidden />
+                    </Button>
+                  </Tooltip>
                 </Dropdown>
-
-                {!isSidebarOpen && (
-                  <Button className="glass-bg" onClick={() => toggleSidebar(true)}>
-                    Métricas
-                  </Button>
-                )}
               </div>
             ) : (
               <Button target="_blank" href={window.location.href.replace(/&embed=true/g, '')}>

--- a/src/antdModal.js
+++ b/src/antdModal.js
@@ -1,0 +1,20 @@
+import { Modal as staticModal } from 'antd';
+
+let impl = staticModal;
+
+/**
+ * Binds App.useApp().modal so confirms/info dialogs respect ConfigProvider theme.
+ * Falls back to static Modal until the shell mounts.
+ */
+export function bindAntdModal(api) {
+  impl = api;
+}
+
+export const appModal = {
+  confirm: (c) => impl.confirm(c),
+  info: (c) => impl.info(c),
+  success: (c) => impl.success(c),
+  error: (c) => impl.error(c),
+  warning: (c) => impl.warning(c),
+  destroyAll: () => impl.destroyAll?.(),
+};

--- a/src/api/airtableFunctions.test.js
+++ b/src/api/airtableFunctions.test.js
@@ -1,0 +1,206 @@
+import commentsHandler from '../../api/airtable/comments.js';
+import metadataHandler from '../../api/airtable/metadata.js';
+
+function createRes() {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: undefined,
+    setHeader(key, value) {
+      this.headers[key] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+const validComment = {
+  latlong: '-30.0346,-51.2177',
+  location: 'Porto Alegre, RS',
+  text: 'Ciclovia sem continuidade.',
+  tags: ['Infraestrutura'],
+};
+
+describe('Airtable Vercel functions', () => {
+  const originalKey = process.env.AIRTABLE_API_KEY;
+  const originalBase = process.env.AIRTABLE_BASE_ID;
+
+  beforeEach(() => {
+    process.env.AIRTABLE_API_KEY = 'test-key';
+    process.env.AIRTABLE_BASE_ID = 'appTest';
+    jest.spyOn(global, 'fetch').mockResolvedValue(jsonResponse(200, { records: [] }));
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.AIRTABLE_API_KEY;
+    else process.env.AIRTABLE_API_KEY = originalKey;
+    if (originalBase === undefined) delete process.env.AIRTABLE_BASE_ID;
+    else process.env.AIRTABLE_BASE_ID = originalBase;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects unsupported methods with 405', async () => {
+    const res = createRes();
+    await commentsHandler({ method: 'PUT' }, res);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.Allow).toBe('GET, POST');
+    expect(res.body).toEqual({ error: 'Method not allowed' });
+  });
+
+  it('GET metadata paginates Airtable and caches the response', async () => {
+    fetch
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          records: [{ id: 'rec1', fields: { location: 'Curitiba' } }],
+          offset: 'page2',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          records: [{ id: 'rec2', fields: { location: 'Recife' } }],
+        })
+      );
+
+    const res = createRes();
+    await metadataHandler({ method: 'GET' }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([
+      { id: 'rec1', fields: { location: 'Curitiba' } },
+      { id: 'rec2', fields: { location: 'Recife' } },
+    ]);
+    expect(res.headers['Cache-Control']).toContain('s-maxage=3600');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(String(fetch.mock.calls[0][0])).toContain('/appTest/Metadata');
+    expect(String(fetch.mock.calls[1][0])).toContain('offset=page2');
+  });
+
+  it('GET comments strips email and solved records', async () => {
+    fetch.mockResolvedValueOnce(
+      jsonResponse(200, {
+        records: [
+          { id: 'tags', fields: { id: 44, tags: ['Infraestrutura', 'Sinalização'] } },
+          {
+            id: 'open',
+            fields: {
+              status: 'Aberta',
+              latlong: '-30.03,-51.21',
+              text: 'buraco',
+              email: 'secret@example.com',
+            },
+          },
+          { id: 'done', fields: { status: 'Resolvida', latlong: '-30.04,-51.22', text: 'ok' } },
+          { id: 'noloc', fields: { status: 'Aberta', text: 'sem ponto' } },
+        ],
+      })
+    );
+
+    const res = createRes();
+    await commentsHandler({ method: 'GET' }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.tagsList).toEqual(['Infraestrutura', 'Sinalização']);
+    expect(res.body.comments).toHaveLength(1);
+    expect(res.body.comments[0].fields.text).toBe('buraco');
+    expect(res.body.comments[0].fields.email).toBeUndefined();
+  });
+
+  it('rejects a filled honeypot without calling Airtable', async () => {
+    const res = createRes();
+    await commentsHandler(
+      { method: 'POST', body: { ...validComment, website: 'http://spam.test' } },
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid request' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid comment payloads', async () => {
+    const res = createRes();
+    await commentsHandler(
+      { method: 'POST', body: { ...validComment, latlong: 'not-a-coord' } },
+      res
+    );
+    expect(res.statusCode).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POST allowlists fields, forces status, and returns 201', async () => {
+    fetch.mockResolvedValueOnce(jsonResponse(200, { records: [{ id: 'created' }] }));
+
+    const res = createRes();
+    await commentsHandler(
+      {
+        method: 'POST',
+        body: {
+          ...validComment,
+          email: 'rider@example.com',
+          status: 'Resolvida',
+          extra: 'nope',
+        },
+      },
+      res
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      records: [
+        {
+          fields: {
+            status: 'Aberta',
+            latlong: '-30.0346,-51.2177',
+            location: 'Porto Alegre, RS',
+            text: 'Ciclovia sem continuidade.',
+            tags: ['Infraestrutura'],
+            email: 'rider@example.com',
+          },
+        },
+      ],
+    });
+  });
+
+  it('returns a generic 502 when Airtable fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { message: 'INVALID_CREDENTIALS_DO_NOT_LEAK' } }),
+    });
+
+    const res = createRes();
+    await metadataHandler({ method: 'GET' }, res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ error: 'Airtable request failed' });
+    expect(JSON.stringify(res.body)).not.toContain('INVALID_CREDENTIALS');
+  });
+
+  it('returns 500 when server env is missing', async () => {
+    delete process.env.AIRTABLE_API_KEY;
+    const res = createRes();
+    await metadataHandler({ method: 'GET' }, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'Airtable is not configured' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AntdAppShell.jsx
+++ b/src/components/AntdAppShell.jsx
@@ -5,16 +5,21 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/pt-br';
 
 import { bindAntdNotification } from '../antdNotification';
+import { bindAntdModal } from '../antdModal';
 import { getAntdConfigProviderProps } from '../config/antdTheme';
 
 dayjs.locale('pt-br');
 
-function NotificationBinder({ children }) {
-  const { notification } = App.useApp();
+function AppApiBinder({ children }) {
+  const { notification, modal } = App.useApp();
 
   useEffect(() => {
     bindAntdNotification(notification);
   }, [notification]);
+
+  useEffect(() => {
+    bindAntdModal(modal);
+  }, [modal]);
 
   return children;
 }
@@ -23,7 +28,7 @@ export default function AntdAppShell({ isDarkMode, children }) {
   return (
     <ConfigProvider locale={ptBR} {...getAntdConfigProviderProps(isDarkMode)}>
       <App>
-        <NotificationBinder>{children}</NotificationBinder>
+        <AppApiBinder>{children}</AppApiBinder>
       </App>
     </ConfigProvider>
   );

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -224,7 +224,7 @@ export const DISABLE_LOCAL_STORAGE = true;
 const URL_PARAMS = new URLSearchParams(window.location.search);
 export const FORCE_RECALCULATE_LENGTHS_ALWAYS = URL_PARAMS.get('debug') === 'true';
 
-export const USE_GEOJSON_SOURCE = true;
+export const USE_GEOJSON_SOURCE = false;
 export const USE_PMTILES_SOURCE = true;
 
 // Providers

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -224,7 +224,6 @@ export const DISABLE_LOCAL_STORAGE = true;
 const URL_PARAMS = new URLSearchParams(window.location.search);
 export const FORCE_RECALCULATE_LENGTHS_ALWAYS = URL_PARAMS.get('debug') === 'true';
 
-export const USE_GEOJSON_SOURCE = false;
 export const USE_PMTILES_SOURCE = true;
 
 // Providers

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -226,6 +226,9 @@ export const FORCE_RECALCULATE_LENGTHS_ALWAYS = URL_PARAMS.get('debug') === 'tru
 
 export const USE_PMTILES_SOURCE = true;
 
+/** Way layers omitted from PMTiles builds — not renderable when map uses PMTiles only. */
+export const PMTILES_EXCLUDED_LAYER_NAMES = new Set(['Baixa velocidade', 'Trilha', 'Proibido']);
+
 // Providers
 
 export const OPENROUTESERVICE_API_KEY = process.env.REACT_APP_OPENROUTESERVICE_API_KEY;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -104,7 +104,9 @@ export const ENABLE_AUTO_AREA_CHANGE_ON_POINT = true;
 // desktop (will require a one-time permission prompt for new users).
 export const ENABLE_AUTOFILL_ORIGIN_ON_PANEL_OPEN = IS_MOBILE;
 export const ENABLE_COMMENTS = !IS_MOBILE;
-export const ENABLE_BOUNDARY_LAYER = false;
+// Master kill switch. When on, the city boundary still only draws while Analytics
+// or Routing is active (see App.needsCityGeoJsonContext) — GeoJSON is deferred otherwise.
+export const ENABLE_BOUNDARY_LAYER = true;
 export const ENABLE_SATELLITE_TOGGLE = false;
 
 const SUPPORTED_COUNTRIES_PROD = Object.freeze([{ code: 'br', labelPt: 'Brasil', flag: '🇧🇷' }]);
@@ -189,7 +191,7 @@ export const INTERACTIVE_LAYERS_ZOOM_THRESHOLD = 15;
 export const COMMENTS_ZOOM_THRESHOLD = 13;
 export const MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD = 12;
 
-const DEFAULT_PMTILES_FILENAME = 'spain.pmtiles';
+const DEFAULT_PMTILES_FILENAME = 'spain-poi.pmtiles';
 export const PMTILES_FILENAME = process.env.REACT_APP_PMTILES_FILENAME || DEFAULT_PMTILES_FILENAME;
 
 /*

--- a/src/config/design-tokens.js
+++ b/src/config/design-tokens.js
@@ -40,6 +40,9 @@ export const mapColors = {
   // Route border (outline): white in dark theme, black in light
   routeBorderDark: '#ffffff',
   routeBorderLight: '#000000',
+  // City admin boundary (Analytics/Routing context) — ciclovia greens, not route outline
+  boundaryLineDark: '#B9FAB7',
+  boundaryLineLight: '#386641',
   // Text/icon halo (readability on map)
   haloDark: '#1c1a17',
   haloLight: '#ffffff',
@@ -144,12 +147,14 @@ export const MAP_COLORS = {
   DARK: {
     STROKE: mapColors.strokeDark,
     ROUTE_BORDER: mapColors.routeBorderDark,
+    BOUNDARY: mapColors.boundaryLineDark,
     HALO: mapColors.haloDark,
     ROUTE_PADDING_LINE: mapColors.routePaddingLineDark,
   },
   LIGHT: {
     STROKE: mapColors.strokeLight,
     ROUTE_BORDER: mapColors.routeBorderLight,
+    BOUNDARY: mapColors.boundaryLineLight,
     HALO: mapColors.haloLight,
     ICON_HALO: mapColors.iconHaloLight,
     ROUTE_PADDING_LINE: mapColors.routePaddingLineLight,

--- a/src/config/design-tokens.test.js
+++ b/src/config/design-tokens.test.js
@@ -81,8 +81,10 @@ describe('design tokens', () => {
     it('has DARK and LIGHT theme keys and CYCLEPATH_FALLBACK', () => {
       expect(MAP_COLORS.DARK.STROKE).toMatch(/^#[0-9a-fA-F]{6}$/);
       expect(MAP_COLORS.DARK.HALO).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(MAP_COLORS.DARK.BOUNDARY).toMatch(/^#[0-9a-fA-F]{6}$/);
       expect(MAP_COLORS.LIGHT.STROKE).toMatch(/^#[0-9a-fA-F]{6}$/);
       expect(MAP_COLORS.LIGHT.HALO).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(MAP_COLORS.LIGHT.BOUNDARY).toMatch(/^#[0-9a-fA-F]{6}$/);
       expect(MAP_COLORS.CYCLEPATH_FALLBACK).toMatch(/^#[0-9a-fA-F]{6}$/);
       expect(MAP_COLORS.LIGHT_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/);
     });

--- a/src/dev/ApiDebugOverlay.jsx
+++ b/src/dev/ApiDebugOverlay.jsx
@@ -366,7 +366,7 @@ export default function ApiDebugOverlay({ initiallyOpen = false }) {
       className={`fixed z-[99999] overflow-hidden bg-gray-800 font-['Inter',system-ui,sans-serif] text-[10px] ${
         IS_MOBILE
           ? 'inset-x-0 bottom-0 w-full pb-[env(safe-area-inset-bottom,0px)]'
-          : 'right-4 w-60 rounded-lg shadow-lg'
+          : 'right-4 rounded-lg shadow-lg'
       }`}
       style={IS_MOBILE ? undefined : { top: desktopTop }}
     >

--- a/src/dev/ApiDebugOverlay.jsx
+++ b/src/dev/ApiDebugOverlay.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { HiOutlineChevronDown as IconChevron } from 'react-icons/hi';
 import { HiBugAnt as IconDebug, HiOutlineXMark as IconClose } from 'react-icons/hi2';
-import { IS_MOBILE, TOPBAR_HEIGHT } from '../config/constants.js';
+import { IS_MOBILE } from '../config/constants.js';
 import { API_COLORS, API_GROUPS, API_LABELS, API_TYPES, subscribe } from './apiTracker.js';
 import { BRAND_LOGO_URLS } from './brandLogos.js';
 import { DATA_SOURCE_STATUS, subscribeDataLoads } from './dataLoadTracker.js';
@@ -286,6 +286,9 @@ function CollapsedSummary({ counts, dataSources }) {
 
 const OPEN_STORAGE_KEY = 'ciclomapa-debug-panel-open';
 
+// No bottom-right map FABs on desktop (geo + route live in the topbar).
+const DESKTOP_BOTTOM_OFFSET_PX = 16;
+
 function readStoredOpen(fallback) {
   try {
     const raw = window.localStorage.getItem(OPEN_STORAGE_KEY);
@@ -342,8 +345,6 @@ export default function ApiDebugOverlay({ initiallyOpen = false }) {
     (group) => group.types.reduce((sum, t) => sum + (snapshot.counts[t] || 0), 0) > 0
   );
 
-  const desktopTop = TOPBAR_HEIGHT + 8;
-
   if (!open) {
     return (
       <button
@@ -351,7 +352,7 @@ export default function ApiDebugOverlay({ initiallyOpen = false }) {
         className={`fixed z-[99999] flex h-4 w-4 cursor-pointer items-center justify-center border-0 bg-transparent p-0 text-gray-500 opacity-40 hover:opacity-90 focus-visible:opacity-90 ${
           IS_MOBILE ? 'right-0.5 bottom-[calc(2px+env(safe-area-inset-bottom,0px))]' : 'right-4'
         }`}
-        style={IS_MOBILE ? undefined : { top: desktopTop }}
+        style={IS_MOBILE ? undefined : { bottom: DESKTOP_BOTTOM_OFFSET_PX }}
         onClick={() => setOpen(true)}
         title="Open debug panel"
         aria-label="Open debug panel"
@@ -368,7 +369,7 @@ export default function ApiDebugOverlay({ initiallyOpen = false }) {
           ? 'inset-x-0 bottom-0 w-full pb-[env(safe-area-inset-bottom,0px)]'
           : 'right-4 rounded-lg shadow-lg'
       }`}
-      style={IS_MOBILE ? undefined : { top: desktopTop }}
+      style={IS_MOBILE ? undefined : { bottom: DESKTOP_BOTTOM_OFFSET_PX }}
     >
       <div
         className="flex cursor-pointer select-none items-center gap-1.5 bg-gray-800 px-2 py-0.5 text-gray-100"

--- a/src/features/map/mapboxGeocoding.js
+++ b/src/features/map/mapboxGeocoding.js
@@ -1,12 +1,12 @@
 /**
- * Reverse geocoding via Mapbox — used for high-frequency map-move area detection.
+ * Reverse geocoding via Mapbox — used when a global search pick doesn't already
+ * carry an area label (App.handleGlobalSearchPlaceSelect).
  *
  * This replaces the Google Geocoding API path that was introduced in the city-switcher-v2
  * refactor (commit 6bccc22). Mapbox handles this use case at a much lower cost since we
  * only need a city/place name string, not Google's richer address components.
  *
  * To swap back to Google:
- *   - Map.js:  change import from `./features/map/mapboxGeocoding.js` to `./googlePlacesClient.js`
  *   - App.js:  change import from `./features/map/mapboxGeocoding.js` to `./googlePlacesClient.js`
  * The Google implementation (reverseGeocodePlace) is preserved there and ready to use.
  */

--- a/src/matchCityAirtableMetadata.test.js
+++ b/src/matchCityAirtableMetadata.test.js
@@ -18,3 +18,48 @@ describe('AirtableDatabase.matchCityMetadataFields', () => {
     expect(db.matchCityMetadataFields(records, 'Curitiba, PR')?.pnb_total).toBe(20);
   });
 });
+
+describe('AirtableDatabase same-origin client', () => {
+  const db = new AirtableDatabase();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('getMetadata returns JSON when the proxy succeeds', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 'rec1', fields: { location: 'Curitiba' } }],
+    });
+
+    await expect(db.getMetadata()).resolves.toEqual([
+      { id: 'rec1', fields: { location: 'Curitiba' } },
+    ]);
+    expect(fetch).toHaveBeenCalledWith('/api/airtable/metadata', undefined);
+  });
+
+  it('getComments throws the server error message', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: 'Airtable request failed' }),
+    });
+
+    await expect(db.getComments()).rejects.toThrow('Airtable request failed');
+  });
+
+  it('create POSTs JSON and throws when the write fails', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'Invalid request' }),
+    });
+
+    await expect(db.create({ text: 'x' })).rejects.toThrow('Invalid request');
+    expect(fetch).toHaveBeenCalledWith('/api/airtable/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'x' }),
+    });
+  });
+});

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -8,7 +8,7 @@
 import { clientsClaim } from 'workbox-core';
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute, NavigationRoute } from 'workbox-routing';
-import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
+import { CacheFirst, NetworkFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { enable as enableNavigationPreload } from 'workbox-navigation-preload';
 
@@ -47,15 +47,6 @@ registerRoute(
   new CacheFirst({
     cacheName: 'nominatim',
     plugins: [new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 24 * 60 * 60 })],
-  })
-);
-
-// StaleWhileRevalidate: Airtable (city metadata, comments)
-registerRoute(
-  ({ url }) => url.hostname === 'api.airtable.com',
-  new StaleWhileRevalidate({
-    cacheName: 'airtable',
-    plugins: [new ExpirationPlugin({ maxEntries: 50, maxAgeSeconds: 7 * 24 * 60 * 60 })],
   })
 );
 

--- a/src/types/mapbox-pmtiles-shim.d.ts
+++ b/src/types/mapbox-pmtiles-shim.d.ts
@@ -1,3 +1,0 @@
-declare module 'mapbox-pmtiles' {
-  export const PmTilesSource: any;
-}

--- a/src/types/mapbox-pmtiles.d.ts
+++ b/src/types/mapbox-pmtiles.d.ts
@@ -1,5 +1,0 @@
-declare module 'mapbox-pmtiles' {
-  // `mapbox-pmtiles` ships TypeScript sources and can fail strict typechecking
-  // inside node_modules. We intentionally treat it as untyped at the app layer.
-  export const PmTilesSource: any;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
     "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
-    "paths": {
-      "mapbox-pmtiles": ["src/types/mapbox-pmtiles-shim"]
-    },
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,11 +2483,6 @@
     get-stream "^6.0.1"
     minimist "^1.2.6"
 
-"@mapbox/mapbox-gl-supported@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz"
-  integrity sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==
-
 "@mapbox/mapbox-sdk@^0.16.2":
   version "0.16.2"
   resolved "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.2.tgz"
@@ -2522,36 +2517,12 @@
   dependencies:
     base-64 "^0.1.0"
 
-"@mapbox/point-geometry@^1.1.0", "@mapbox/point-geometry@~1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz"
-  integrity sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==
-
 "@mapbox/polyline@^1.0.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@mapbox/polyline/-/polyline-1.2.1.tgz"
   integrity sha512-sn0V18O3OzW4RCcPoUIVDWvEGQaBNH9a0y5lgqrf5hUycyw1CzrhEoxV5irzrMNXKCkw1xRsZXcaVbsVZggHXA==
   dependencies:
     meow "^9.0.0"
-
-"@mapbox/tiny-sdf@^2.0.6":
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz"
-  integrity sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==
-
-"@mapbox/unitbezier@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz"
-  integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
-
-"@mapbox/vector-tile@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz"
-  integrity sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==
-  dependencies:
-    "@mapbox/point-geometry" "~1.1.0"
-    "@types/geojson" "^7946.0.16"
-    pbf "^4.0.1"
 
 "@napi-rs/wasm-runtime@^1.0.3":
   version "1.1.4"
@@ -3894,14 +3865,7 @@
     "@types/qs" "*"
     "@types/serve-static" "^1"
 
-"@types/geojson-vt@^3.2.5":
-  version "3.2.5"
-  resolved "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz"
-  integrity sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==
-  dependencies:
-    "@types/geojson" "*"
-
-"@types/geojson@*", "@types/geojson@^7946.0", "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.16":
+"@types/geojson@*", "@types/geojson@^7946.0", "@types/geojson@^7946.0.10":
   version "7946.0.16"
   resolved "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz"
   integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
@@ -3991,13 +3955,6 @@
   resolved "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
-"@types/mapbox-gl@^2.7.21":
-  version "2.7.21"
-  resolved "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.21.tgz"
-  integrity sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==
-  dependencies:
-    "@types/geojson" "*"
-
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz"
@@ -4036,11 +3993,6 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
-
-"@types/pbf@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz"
-  integrity sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==
 
 "@types/prettier@^2.1.5":
   version "2.7.3"
@@ -4145,13 +4097,6 @@
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
-
-"@types/supercluster@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz"
-  integrity sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==
-  dependencies:
-    "@types/geojson" "*"
 
 "@types/trusted-types@^2.0.2":
   version "2.0.7"
@@ -5806,11 +5751,6 @@ char-regex@^2.0.0:
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz"
   integrity sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==
 
-cheap-ruler@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz"
-  integrity sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==
-
 check-types@^11.2.3:
   version "11.2.3"
   resolved "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz"
@@ -6333,11 +6273,6 @@ css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
-
-csscolorparser@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz"
-  integrity sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==
 
 cssdb@^7.1.0:
   version "7.11.2"
@@ -6922,11 +6857,6 @@ duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
-
-earcut@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz"
-  integrity sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -8257,11 +8187,6 @@ geojson-numeric@0.2.1:
     concat-stream "2.0.0"
     optimist "~0.3.5"
 
-geojson-vt@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz"
-  integrity sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==
-
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
@@ -8366,11 +8291,6 @@ gh-pages@^6.3.0:
     find-cache-dir "^3.3.1"
     fs-extra "^11.1.1"
     globby "^11.1.0"
-
-gl-matrix@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz"
-  integrity sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -10169,11 +10089,6 @@ jsprim@^1.2.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-kdbush@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz"
-  integrity sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==
-
 keyv@^4.0.0, keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"
@@ -10505,56 +10420,10 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-mapbox-gl@^3.1.2:
-  version "3.24.0"
-  resolved "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.24.0.tgz"
-  integrity sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA==
-  dependencies:
-    "@mapbox/mapbox-gl-supported" "^3.0.0"
-    "@mapbox/point-geometry" "^1.1.0"
-    "@mapbox/tiny-sdf" "^2.0.6"
-    "@mapbox/unitbezier" "^0.0.1"
-    "@mapbox/vector-tile" "^2.0.4"
-    "@types/geojson" "^7946.0.16"
-    "@types/geojson-vt" "^3.2.5"
-    "@types/pbf" "^3.0.5"
-    "@types/supercluster" "^7.1.3"
-    cheap-ruler "^4.0.0"
-    csscolorparser "~1.0.3"
-    earcut "^3.0.1"
-    geojson-vt "^4.0.2"
-    gl-matrix "^3.4.4"
-    kdbush "^4.0.2"
-    martinez-polygon-clipping "^0.8.1"
-    murmurhash-js "^1.0.0"
-    pbf "^4.0.1"
-    potpack "^2.0.0"
-    quickselect "^3.0.0"
-    supercluster "^8.0.1"
-    tinyqueue "^3.0.0"
-
 mapbox-gl@^3.21.0:
   version "3.27.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-3.27.0.tgz#134c2b4a64910e7420305bf1078156e21293cfc4"
   integrity sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g==
-
-mapbox-pmtiles@^1.0.54:
-  version "1.0.56"
-  resolved "https://registry.npmjs.org/mapbox-pmtiles/-/mapbox-pmtiles-1.0.56.tgz"
-  integrity sha512-DcMj0ZpDypMskqU4WSNTlt+2ACTihK/qjtWnyVnJF51f5F5fDLxFUWzRgEn4utSvSuynm5+vlJt+k8U83xuVsQ==
-  dependencies:
-    "@types/mapbox-gl" "^2.7.21"
-    mapbox-gl "^3.1.2"
-    pmtiles "^3.0.3"
-
-martinez-polygon-clipping@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz"
-  integrity sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==
-  dependencies:
-    robust-predicates "^2.0.4"
-    splaytree "^0.1.4"
-    tinyqueue "3.0.0"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -10833,11 +10702,6 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
-
-murmurhash-js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz"
-  integrity sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==
 
 mz@^2.7.0:
   version "2.7.0"
@@ -11463,13 +11327,6 @@ pbf@^3.0.4:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
 
-pbf@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz"
-  integrity sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==
-  dependencies:
-    resolve-protobuf-schema "^2.1.0"
-
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
@@ -11579,7 +11436,7 @@ playwright@1.60.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-pmtiles@^3.0.3, pmtiles@^3.2.1:
+pmtiles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz"
   integrity sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==
@@ -12418,11 +12275,6 @@ quickselect@^2.0.0:
   resolved "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz"
   integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
 
-quickselect@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz"
-  integrity sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==
-
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
@@ -13013,11 +12865,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-robust-predicates@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz"
-  integrity sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==
-
 rolldown@1.0.0-beta.35:
   version "1.0.0-beta.35"
   resolved "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.35.tgz"
@@ -13588,11 +13435,6 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-splaytree@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz"
-  integrity sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -13929,13 +13771,6 @@ sucrase@^3.35.0:
     tinyglobby "^0.2.11"
     ts-interface-checker "^0.1.9"
 
-supercluster@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz"
-  integrity sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==
-  dependencies:
-    kdbush "^4.0.2"
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -14239,11 +14074,6 @@ tinyglobby@^0.2.11:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
-
-tinyqueue@3.0.0, tinyqueue@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz"
-  integrity sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==
 
 tmpl@1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10505,7 +10505,7 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-mapbox-gl@^3.1.2, mapbox-gl@^3.19.1:
+mapbox-gl@^3.1.2:
   version "3.24.0"
   resolved "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.24.0.tgz"
   integrity sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA==
@@ -10532,6 +10532,11 @@ mapbox-gl@^3.1.2, mapbox-gl@^3.19.1:
     quickselect "^3.0.0"
     supercluster "^8.0.1"
     tinyqueue "^3.0.0"
+
+mapbox-gl@^3.21.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-3.27.0.tgz#134c2b4a64910e7420305bf1078156e21293cfc4"
+  integrity sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g==
 
 mapbox-pmtiles@^1.0.54:
   version "1.0.56"


### PR DESCRIPTION
## Summary
- Proxy metadata and comments through `/api/airtable/*` so the Airtable token stays server-only.
- Validate comment posts (allowlist, honeypot, status set on the server) and strip emails from GET responses.
- Also includes the local `vercel dev` CRACO + source-map-loader quieting so this stack is usable before it picks up master.

## Test plan
- [ ] Set `AIRTABLE_API_KEY` / `AIRTABLE_BASE_ID` in Vercel Preview (and locally for `yarn dev:vercel`).
- [ ] Load a city and confirm analytics metadata still matches.
- [ ] On desktop, load comments and submit a valid one.
- [ ] Confirm a filled honeypot does not create a record, and a failed write does not show success.
- [ ] After preview looks good, rotate/revoke the old `REACT_APP_AIRTABLE_API_KEY` token.


Made with [Cursor](https://cursor.com)