### PR TITLE
Track anonymous users in Sentry

### DIFF
--- a/src/PrivacyPolicy.jsx
+++ b/src/PrivacyPolicy.jsx
@@ -7,7 +7,7 @@ import Logo from './components/Logo';
 import { handleModalKeyDown, setupModalFocus, restoreModalFocus } from './modalFocusTrap';
 
 const CONTACT_EMAIL = 'contato@ciclomapa.org.br';
-const LAST_UPDATED = '31/05/2026';
+const LAST_UPDATED = '07/09/2026';
 
 const paragraphClass = 'text-sm sm:text-base leading-relaxed text-gray-300 mb-3';
 const listClass =
@@ -183,6 +183,10 @@ function getSections() {
             <li>sistema operacional;</li>
             <li>tipo e versão do navegador;</li>
             <li>informações derivadas do endereço de IP;</li>
+            <li>
+              um identificador aleatório salvo no navegador, usado para estimar quantas pessoas
+              encontraram o mesmo erro, sem incluir nome ou e-mail;
+            </li>
             <li>registros técnicos de erro ou funcionamento;</li>
             <li>dados agregados sobre uso da plataforma.</li>
           </ul>

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -34,4 +34,16 @@ if (dsn && environment) {
       'ResizeObserver loop completed with undelivered notifications',
     ],
   });
+
+  let anonymousUserId;
+  try {
+    anonymousUserId = window.localStorage.getItem('ciclomapa:sentry-user-id');
+    if (!anonymousUserId) {
+      anonymousUserId = window.crypto.randomUUID();
+      window.localStorage.setItem('ciclomapa:sentry-user-id', anonymousUserId);
+    }
+  } catch {
+    anonymousUserId = window.crypto.randomUUID();
+  }
+  Sentry.setUser({ id: anonymousUserId });
 }


### PR DESCRIPTION
## Summary
- Persist a random Sentry user id in localStorage so issue counts actually show affected browsers.
- Keep names, emails, and default PII off.
- Mention that identifier in the privacy policy.

## Test plan
- [ ] Load production/preview, trigger a console warning, confirm the Sentry event has a `user.id`.
- [ ] Reload and trigger again: same id.
- [ ] Privacy policy shows the new identifier bullet and updated date.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy’s last updated date.
  * Added disclosure of an anonymous browser-saved identifier used to estimate error occurrences.

* **Bug Fixes**
  * Improved error reporting consistency by associating reports with a persistent anonymous identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->