### PR TITLE
Silence frequent Mapbox and Google Maps warnings

### DIFF
--- a/src/GooglePlacesGeocoder.js
+++ b/src/GooglePlacesGeocoder.js
@@ -353,6 +353,7 @@ function ensureGoogleMapsScriptLoaded(apiKey, language, region) {
         libraries: 'places',
         language,
         region,
+        loading: 'async',
       }).toString()}`;
       script.onload = () => resolve();
       script.onerror = () => {

--- a/src/Map.js
+++ b/src/Map.js
@@ -81,6 +81,13 @@ export function flyMapToCityFocus(map, centerLngLat, placeName) {
 /** GeoJSON source holding endpoint circles used alongside route-mode POI `within` filters */
 const ROUTE_ENDPOINT_POI_ZONES_SOURCE_ID = 'route-endpoint-poi-zones';
 
+const MISSING_BASEMAP_IMAGES = new Set([
+  'turning-circle-outline',
+  'turning-circle',
+  'oneway-small',
+  'oneway-large',
+]);
+
 /** Geo sources for app data layers; basemap (e.g. composite) is everything else. */
 const CICLOMAPA_DATA_SOURCES = new Set([
   'osmdata',
@@ -925,7 +932,6 @@ class Map extends Component {
           'source-layer': sourceLayer,
           filter: filters,
           paint: {
-            'line-occlusion-opacity': 1,
             'line-opacity': [
               'case',
               ['boolean', ['feature-state', 'selected'], false],
@@ -2677,6 +2683,16 @@ class Map extends Component {
     if (!this.map) {
       return;
     }
+
+    this.map.on('styleimagemissing', ({ id }) => {
+      if (MISSING_BASEMAP_IMAGES.has(id) && !this.map.hasImage(id)) {
+        this.map.addImage(id, {
+          width: 1,
+          height: 1,
+          data: new Uint8Array(4),
+        });
+      }
+    });
 
     // Mapbox tracks window resize, but the map container can change size without one
     // (e.g. --viewport-height updates from visualViewport in index.js). ResizeObserver


### PR DESCRIPTION
## Summary
- Load the Google Maps JS API with `loading=async` so Google stops warning about the script tag.
- Drop `line-occlusion-opacity` on interactive cycle layers (it is invalid when `line-opacity` is data-driven).
- Provide transparent fallbacks for missing basemap sprites (`turning-circle`, `oneway-small`, `oneway-large`, etc).

The hosted Mapbox `light` deprecation is still coming from the Studio styles themselves, so that one is not in this PR.

## Test plan
- [ ] Open a city map, hover/select cycle infrastructure: no occlusion-opacity console warnings.
- [ ] Zoom around roads: no missing `turning-circle` / `oneway-*` image errors.
- [ ] Trigger Places search: no `loading=async` warning.


Made with [Cursor](https://cursor.com)